### PR TITLE
Provide a --target-branch option in the cli

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,6 +31,10 @@ fn merge_request_command() -> Command {
                     arg!(--auto "Do not prompt for confirmation")
                         .action(ArgAction::SetTrue)
                         .required(false),
+                )
+                .arg(
+                    arg!(--"target-branch" <TARGETBRANCH> "Target branch of the merge request instead of default project's upstream branch")
+                        .required(false),
                 ),
         )
         .subcommand(
@@ -105,10 +109,12 @@ pub fn parse_cli() -> Option<CliOptions> {
             Some(("create", sub_matches)) => {
                 let title = sub_matches.get_one::<String>("title");
                 let description = sub_matches.get_one::<String>("description");
+                let target_branch = sub_matches.get_one::<String>("target-branch");
                 let noprompt = sub_matches.get_flag("auto");
                 return Some(CliOptions::MergeRequest(MergeRequestOptions::Create {
                     title: title.as_ref().map(|s| s.to_string()),
                     description: description.as_ref().map(|s| s.to_string()),
+                    target_branch: target_branch.as_ref().map(|s| s.to_string()),
                     noprompt,
                     refresh_cache,
                 }));
@@ -182,6 +188,7 @@ pub enum MergeRequestOptions {
     Create {
         title: Option<String>,
         description: Option<String>,
+        target_branch: Option<String>,
         noprompt: bool,
         refresh_cache: bool,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ fn main() -> Result<()> {
                 MergeRequestOptions::Create {
                     title,
                     description,
+                    target_branch,
                     noprompt,
                     refresh_cache,
                 } => {
@@ -42,7 +43,14 @@ fn main() -> Result<()> {
                         refresh_cache,
                     ));
                     let remote = get_remote(domain, path, config.clone(), runner)?;
-                    merge_request::open(remote, Arc::new(config), title, description, noprompt)
+                    merge_request::open(
+                        remote,
+                        Arc::new(config),
+                        title,
+                        description,
+                        target_branch,
+                        noprompt,
+                    )
                 }
                 MergeRequestOptions::List {
                     state,

--- a/src/merge_request.rs
+++ b/src/merge_request.rs
@@ -25,6 +25,7 @@ pub fn open(
     config: Arc<impl ConfigProperties>,
     title: Option<String>,
     description: Option<String>,
+    target_branch: Option<String>,
     noprompt: bool,
 ) -> Result<()> {
     // data gathering stage. Gather local repo and remote project data.
@@ -52,7 +53,7 @@ pub fn open(
         }
     }
     let source_branch = &repo.current_branch();
-    let target_branch = project.default_branch();
+    let target_branch = &target_branch.unwrap_or(project.default_branch().to_string());
     let title = title.unwrap_or(repo.title().to_string());
     let description = description.unwrap_or(repo.last_commit_message().to_string());
     let preferred_assignee_username = config.preferred_assignee_username().to_string();


### PR DESCRIPTION
This allows the user to target a different branch other than the
default project upstream branch, such as main.

Closes #14