### PR TITLE
shell test: Use bash to execute shell command

### DIFF
--- a/tests/shell_test.rs
+++ b/tests/shell_test.rs
@@ -46,7 +46,7 @@ fn test_execute_shell_cmd_with_error_cmd_fails_to_stderr() {
     file.set_permissions(perms).unwrap();
     // flush and close file
     drop(file);
-    let cmd = ["sh", "-c", &file_path.to_string_lossy()];
+    let cmd = ["bash", "-c", &file_path.to_string_lossy()];
     let err = runner.run(cmd).unwrap_err();
     assert_eq!(err.to_string(), "This is a failure message");
 }


### PR DESCRIPTION
Fixes test that was failing in MacOS:

```
assertion `left == right` failed
  left: "-n This is a failure message\n"
 right: "This is a failure message"
```

The reason is because we are using `sh`:

In MacOS `man echo`:

```verbatim
the builtin echo in sh(1) does not accept the -n option.  Consult
     the builtin(1) manual page
```