### PR TITLE
Add support for browsing CI/CD pipelines

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,6 +111,8 @@ enum BrowseSubcommand {
     Repo,
     #[clap(name = "mr", about = "Open the merge requests using your browser")]
     MergeRequest(MergeRequestBrowse),
+    #[clap(name = "pp", about = "Open the ci/cd pipelines using your browser")]
+    Pipelines,
 }
 
 #[derive(Parser)]
@@ -173,6 +175,9 @@ pub fn parse_cli() -> Option<CliOptions> {
                     }
                     return Some(CliOptions::Browse(BrowseOptions::MergeRequests));
                 }
+                BrowseSubcommand::Pipelines => {
+                    return Some(CliOptions::Browse(BrowseOptions::Pipelines));
+                }
             }
         }
     }
@@ -188,7 +193,7 @@ pub enum BrowseOptions {
     Repo,
     MergeRequests,
     MergeRequestId(i64),
-    // TODO Pipelines/Actions, close MRs
+    Pipelines,
 }
 
 pub enum MergeRequestOptions {

--- a/src/github.rs
+++ b/src/github.rs
@@ -158,6 +158,7 @@ impl<R: HttpRunner<Response = Response>> RemoteProject for Github<R> {
             BrowseOptions::Repo => base_url,
             BrowseOptions::MergeRequests => format!("{}/pulls", base_url),
             BrowseOptions::MergeRequestId(id) => format!("{}/pull/{}", base_url, id),
+            BrowseOptions::Pipelines => format!("{}/actions", base_url),
         }
     }
 }

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -280,6 +280,7 @@ impl<R: HttpRunner<Response = Response>> RemoteProject for Gitlab<R> {
             BrowseOptions::Repo => base_url,
             BrowseOptions::MergeRequests => format!("{}/merge_requests", base_url),
             BrowseOptions::MergeRequestId(id) => format!("{}/merge_requests/{}", base_url, id),
+            BrowseOptions::Pipelines => format!("{}/pipelines", base_url),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,11 @@ fn main() -> Result<()> {
                         remote.get_url(BrowseOptions::MergeRequestId(id)),
                     )?)
                 }
+                BrowseOptions::Pipelines => {
+                    let runner = Arc::new(http::Client::new(FileCache::new(config.clone()), false));
+                    let remote = get_remote(domain, path, config, runner)?;
+                    Ok(open::that(remote.get_url(BrowseOptions::Pipelines))?)
+                }
             }
         }
     }


### PR DESCRIPTION
```sh
gr br pp
```

will open github actions or gitlab pipelines depending on where the repository is hosted.

Signed-off-by: Jordi Carrillo Bosch <jordilin@gmail.com>