### PR TITLE
Refactor cli - make use of impl From

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -129,36 +129,8 @@ struct MergeRequestBrowse {
 pub fn parse_cli() -> Option<CliOptions> {
     let args = Args::parse();
     match args.command {
-        Command::MergeRequest(sub_matches) => match sub_matches.subcommand {
-            MergeRequestSubcommand::Create(sub_matches) => {
-                Some(CliOptions::MergeRequest(sub_matches.into()))
-            }
-            MergeRequestSubcommand::List(sub_matches) => {
-                Some(CliOptions::MergeRequest(sub_matches.into()))
-            }
-            MergeRequestSubcommand::Merge(sub_matches) => {
-                Some(CliOptions::MergeRequest(sub_matches.into()))
-            }
-            MergeRequestSubcommand::Checkout(sub_matches) => {
-                Some(CliOptions::MergeRequest(sub_matches.into()))
-            }
-            MergeRequestSubcommand::Close(sub_matches) => {
-                Some(CliOptions::MergeRequest(sub_matches.into()))
-            }
-        },
-        Command::Browse(sub_matches) => {
-            let br_cmd = sub_matches.subcommand.unwrap_or(BrowseSubcommand::Repo);
-            match br_cmd {
-                BrowseSubcommand::Repo => Some(CliOptions::Browse(BrowseOptions::Repo)),
-                BrowseSubcommand::MergeRequest(sub_matches) => {
-                    if let Some(id) = sub_matches.id {
-                        return Some(CliOptions::Browse(BrowseOptions::MergeRequestId(id)));
-                    }
-                    Some(CliOptions::Browse(BrowseOptions::MergeRequests))
-                }
-                BrowseSubcommand::Pipelines => Some(CliOptions::Browse(BrowseOptions::Pipelines)),
-            }
-        }
+        Command::MergeRequest(sub_matches) => Some(CliOptions::MergeRequest(sub_matches.into())),
+        Command::Browse(sub_matches) => Some(CliOptions::Browse(sub_matches.into())),
     }
 }
 
@@ -211,6 +183,38 @@ impl From<CheckoutMergeRequest> for MergeRequestOptions {
 impl From<CloseMergeRequest> for MergeRequestOptions {
     fn from(options: CloseMergeRequest) -> Self {
         MergeRequestOptions::Close { id: options.id }
+    }
+}
+
+impl From<MergeRequestCommand> for MergeRequestOptions {
+    fn from(options: MergeRequestCommand) -> Self {
+        match options.subcommand {
+            MergeRequestSubcommand::Create(options) => options.into(),
+            MergeRequestSubcommand::List(options) => options.into(),
+            MergeRequestSubcommand::Merge(options) => options.into(),
+            MergeRequestSubcommand::Checkout(options) => options.into(),
+            MergeRequestSubcommand::Close(options) => options.into(),
+        }
+    }
+}
+
+impl From<MergeRequestBrowse> for BrowseOptions {
+    fn from(options: MergeRequestBrowse) -> Self {
+        match options.id {
+            Some(id) => BrowseOptions::MergeRequestId(id),
+            None => BrowseOptions::MergeRequests,
+        }
+    }
+}
+
+impl From<BrowseCommand> for BrowseOptions {
+    fn from(options: BrowseCommand) -> Self {
+        match options.subcommand {
+            Some(BrowseSubcommand::Repo) => BrowseOptions::Repo,
+            Some(BrowseSubcommand::MergeRequest(options)) => options.into(),
+            Some(BrowseSubcommand::Pipelines) => BrowseOptions::Pipelines,
+            None => BrowseOptions::Repo,
+        }
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,6 +147,10 @@ pub enum BrowseOptions {
     Pipelines,
 }
 
+// From impls - private clap structs to public domain structs
+// Mainly to avoid propagating clap further down the stack as changes in the
+// clap API could break other parts of the code.
+
 impl From<CreateMergeRequest> for MergeRequestOptions {
     fn from(options: CreateMergeRequest) -> Self {
         MergeRequestOptions::Create {
@@ -213,6 +217,7 @@ impl From<BrowseCommand> for BrowseOptions {
             Some(BrowseSubcommand::Repo) => BrowseOptions::Repo,
             Some(BrowseSubcommand::MergeRequest(options)) => options.into(),
             Some(BrowseSubcommand::Pipelines) => BrowseOptions::Pipelines,
+            // defaults to open repo in browser
             None => BrowseOptions::Repo,
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -131,37 +131,32 @@ pub fn parse_cli() -> Option<CliOptions> {
     match args.command {
         Command::MergeRequest(sub_matches) => match sub_matches.subcommand {
             MergeRequestSubcommand::Create(sub_matches) => {
-                return Some(CliOptions::MergeRequest(sub_matches.into()));
+                Some(CliOptions::MergeRequest(sub_matches.into()))
             }
             MergeRequestSubcommand::List(sub_matches) => {
-                return Some(CliOptions::MergeRequest(sub_matches.into()));
+                Some(CliOptions::MergeRequest(sub_matches.into()))
             }
             MergeRequestSubcommand::Merge(sub_matches) => {
-                return Some(CliOptions::MergeRequest(sub_matches.into()));
+                Some(CliOptions::MergeRequest(sub_matches.into()))
             }
-
             MergeRequestSubcommand::Checkout(sub_matches) => {
-                return Some(CliOptions::MergeRequest(sub_matches.into()));
+                Some(CliOptions::MergeRequest(sub_matches.into()))
             }
             MergeRequestSubcommand::Close(sub_matches) => {
-                return Some(CliOptions::MergeRequest(sub_matches.into()));
+                Some(CliOptions::MergeRequest(sub_matches.into()))
             }
         },
         Command::Browse(sub_matches) => {
             let br_cmd = sub_matches.subcommand.unwrap_or(BrowseSubcommand::Repo);
             match br_cmd {
-                BrowseSubcommand::Repo => {
-                    return Some(CliOptions::Browse(BrowseOptions::Repo));
-                }
+                BrowseSubcommand::Repo => Some(CliOptions::Browse(BrowseOptions::Repo)),
                 BrowseSubcommand::MergeRequest(sub_matches) => {
                     if let Some(id) = sub_matches.id {
                         return Some(CliOptions::Browse(BrowseOptions::MergeRequestId(id)));
                     }
-                    return Some(CliOptions::Browse(BrowseOptions::MergeRequests));
+                    Some(CliOptions::Browse(BrowseOptions::MergeRequests))
                 }
-                BrowseSubcommand::Pipelines => {
-                    return Some(CliOptions::Browse(BrowseOptions::Pipelines));
-                }
+                BrowseSubcommand::Pipelines => Some(CliOptions::Browse(BrowseOptions::Pipelines)),
             }
         }
     }


### PR DESCRIPTION
cli: impl From for clap structs

Maps clap structs to public domain structs. Simplify logic.