### PR TITLE
Config for caching HTTP responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Cache expiration configuration has three keys:
   project. This information does not change often, so a long expiration is fine.
 - `<domain>`.cache_api_pipeline_expiration: List pipelines, get a pipeline, etc...
 
+The values for these keys can accept any number followed by `s` for seconds, `m`
+for minutes, `h` for hours, `d` for days. For example, `5m` means 5 minutes,
+`5d` means 5 days, `0s` means immediate expiration.
+
 If omitted, the default is immediate expiration, so read operations are always
 pulled from the remote.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ gitlab.com.api_token=<your api token>
 gitlab.com.cache_location=/home/<youruser>/.cache/gr
 gitlab.com.preferred_assignee_username=<your username>
 gitlab.com.merge_request_description_signature=<your signature, @someone, etc...>
+# Expire read merge requests in 5 minutes
+gitlab.com.cache_api_merge_request_expiration=5m
+# Expire read project metadata, members of a project in 5 days
+gitlab.com.cache_api_project_expiration=5d
+# Pipelines are read often, change often, so expire immediately.
+gitlab.com.cache_api_pipeline_expiration=0s
+
 
 # Github
 github.com.api_token=<your api token>
@@ -79,6 +86,17 @@ github.com.preferred_assignee_username=<your username>
 gitlab.mycompany.com.api_token=<your api token>
 ...
 ```
+
+Cache expiration configuration has three keys:
+
+- `<domain>`.cache_api_merge_request_expiration: List merge_requests, get a
+  merge request, etc... Any read operation involving merge/pull requests.
+- `<domain>`.cache_api_project_expiration: Get project metadata, members of a
+  project. This information does not change often, so a long expiration is fine.
+- `<domain>`.cache_api_pipeline_expiration: List pipelines, get a pipeline, etc...
+
+If omitted, the default is immediate expiration, so read operations are always
+pulled from the remote.
 
 ### Example open a merge/pull request
 

--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -31,7 +31,7 @@ pub trait Cicd {
 /// global configuration.
 /// This is for read requests only, so that would be list merge_requests, list
 /// pipelines, get one merge request information, etc...
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub enum ApiOperation {
     MergeRequest,
     Pipeline,

--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::{
     cli::BrowseOptions,
     io::CmdInfo,
@@ -38,6 +40,16 @@ pub enum ApiOperation {
     // Project members, project data such as default upstream branch, project
     // id, etc...any metadata related to the project.
     Project,
+}
+
+impl Display for ApiOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiOperation::MergeRequest => write!(f, "merge_request"),
+            ApiOperation::Pipeline => write!(f, "pipeline"),
+            ApiOperation::Project => write!(f, "project"),
+        }
+    }
 }
 
 pub trait Remote: RemoteProject + MergeRequest + Cicd + Send + Sync + 'static {}

--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -26,4 +26,18 @@ pub trait Cicd {
     fn get_pipeline(&self, id: i64) -> Result<Pipeline>;
 }
 
+/// Types of API resources attached to a request. The request will carry this
+/// information so we can decide if we need to use the cache or not based on
+/// global configuration.
+/// This is for read requests only, so that would be list merge_requests, list
+/// pipelines, get one merge request information, etc...
+#[derive(Clone, Debug, PartialEq)]
+pub enum ApiOperation {
+    MergeRequest,
+    Pipeline,
+    // Project members, project data such as default upstream branch, project
+    // id, etc...any metadata related to the project.
+    Project,
+}
+
 pub trait Remote: RemoteProject + MergeRequest + Cicd + Send + Sync + 'static {}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -8,9 +8,9 @@ use crate::Result;
 pub use inmemory::InMemoryCache;
 pub use nocache::NoCache;
 
-pub trait Cache {
-    fn get(&self, key: &str) -> Result<CacheState>;
-    fn set(&self, key: &str, value: &Response) -> Result<()>;
+pub trait Cache<K = String> {
+    fn get(&self, key: &K) -> Result<CacheState>;
+    fn set(&self, key: &K, value: &Response) -> Result<()>;
 }
 
 pub enum CacheState {

--- a/src/cache/filesystem.rs
+++ b/src/cache/filesystem.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 use crate::cache::Cache;
 use crate::http::Resource;
 use crate::io::{self, Response};
-use crate::time::{self, Seconds};
+use crate::time::Seconds;
 
 use super::CacheState;
 
@@ -83,10 +83,10 @@ impl<C: ConfigProperties> FileCache<C> {
     }
 
     fn expired(&self, key: &Resource, path: String) -> Result<bool> {
-        let cache_expiration = time::string_to_seconds(
-            self.config
-                .get_cache_expiration(&key.api_operation.as_ref().unwrap()),
-        )?;
+        let cache_expiration = self
+            .config
+            .get_cache_expiration(&key.api_operation.as_ref().unwrap())
+            .try_into()?;
         expired(|| get_file_mtime_elapsed(path.as_str()), cache_expiration)
     }
 }

--- a/src/cache/filesystem.rs
+++ b/src/cache/filesystem.rs
@@ -13,7 +13,7 @@ use super::CacheState;
 
 use crate::config::ConfigProperties;
 
-use crate::error;
+use crate::error::{self, AddContext, GRError};
 use crate::Result;
 
 pub struct FileCache<C> {
@@ -86,7 +86,13 @@ impl<C: ConfigProperties> FileCache<C> {
         let cache_expiration = self
             .config
             .get_cache_expiration(&key.api_operation.as_ref().unwrap())
-            .try_into()?;
+            .try_into()
+            .err_context(GRError::ConfigurationError(format!(
+                "Cannot retrieve cache expiration time. \
+                 Check your configuration file and make sure the key \
+                 <domain>.cache_api_{}_expiration has a valid time format.",
+                &key.api_operation.as_ref().unwrap()
+            )))?;
         expired(|| get_file_mtime_elapsed(path.as_str()), cache_expiration)
     }
 }

--- a/src/cache/filesystem.rs
+++ b/src/cache/filesystem.rs
@@ -5,6 +5,7 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use sha2::{Digest, Sha256};
 
 use crate::cache::Cache;
+use crate::http::Resource;
 use crate::io::{self, Response};
 
 use super::CacheState;
@@ -81,9 +82,9 @@ impl<C: ConfigProperties> FileCache<C> {
     }
 }
 
-impl<C: ConfigProperties> Cache for FileCache<C> {
-    fn get(&self, key: &str) -> Result<CacheState> {
-        let path = self.get_cache_file(key);
+impl<C: ConfigProperties> Cache<Resource> for FileCache<C> {
+    fn get(&self, key: &Resource) -> Result<CacheState> {
+        let path = self.get_cache_file(&key.url);
         if let Ok(f) = File::open(path) {
             let mut f = BufReader::new(f);
             self.get_cache_data(&mut f)
@@ -92,8 +93,8 @@ impl<C: ConfigProperties> Cache for FileCache<C> {
         }
     }
 
-    fn set(&self, key: &str, value: &Response) -> Result<()> {
-        let path = self.get_cache_file(key);
+    fn set(&self, key: &Resource, value: &Response) -> Result<()> {
+        let path = self.get_cache_file(&key.url);
         let f = File::create(path)?;
         let f = BufWriter::new(f);
         self.persist_cache_data(value, f)?;

--- a/src/cache/nocache.rs
+++ b/src/cache/nocache.rs
@@ -5,11 +5,11 @@ use crate::Result;
 
 pub struct NoCache;
 
-impl Cache for NoCache {
-    fn get(&self, _key: &str) -> Result<CacheState> {
+impl<K> Cache<K> for NoCache {
+    fn get(&self, _key: &K) -> Result<CacheState> {
         Ok(CacheState::None)
     }
-    fn set(&self, _key: &str, _value: &Response) -> Result<()> {
+    fn set(&self, _key: &K, _value: &Response) -> Result<()> {
         Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ pub trait ConfigProperties {
     fn merge_request_description_signature(&self) -> &str {
         ""
     }
-    fn get_cache_expiration(&self, _api_operation: ApiOperation) -> &str {
+    fn get_cache_expiration(&self, _api_operation: &ApiOperation) -> &str {
         ""
     }
 }
@@ -149,7 +149,7 @@ impl ConfigProperties for Config {
         &self.merge_request_description_signature
     }
 
-    fn get_cache_expiration(&self, api_operation: ApiOperation) -> &str {
+    fn get_cache_expiration(&self, api_operation: &ApiOperation) -> &str {
         let expiration = self.cache_expirations.get(&api_operation);
         match expiration {
             Some(expiration) => expiration,
@@ -175,7 +175,7 @@ impl ConfigProperties for Arc<Config> {
         &self.merge_request_description_signature
     }
 
-    fn get_cache_expiration(&self, _api_operation: ApiOperation) -> &str {
+    fn get_cache_expiration(&self, _api_operation: &ApiOperation) -> &str {
         ""
     }
 }
@@ -283,10 +283,10 @@ mod test {
         let config = Config::new(reader, domain).unwrap();
         assert_eq!(
             "2h",
-            config.get_cache_expiration(ApiOperation::MergeRequest)
+            config.get_cache_expiration(&ApiOperation::MergeRequest)
         );
-        assert_eq!("1h", config.get_cache_expiration(ApiOperation::Pipeline));
-        assert_eq!("3h", config.get_cache_expiration(ApiOperation::Project));
+        assert_eq!("1h", config.get_cache_expiration(&ApiOperation::Pipeline));
+        assert_eq!("3h", config.get_cache_expiration(&ApiOperation::Project));
     }
 
     #[test]
@@ -300,6 +300,6 @@ mod test {
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Config::new(reader, domain).unwrap();
-        assert_eq!("", config.get_cache_expiration(ApiOperation::MergeRequest));
+        assert_eq!("", config.get_cache_expiration(&ApiOperation::MergeRequest));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 //! Config file parsing and validation.
 
+use crate::api_traits::ApiOperation;
 use crate::error;
 use crate::Result;
 use std::sync::Arc;
@@ -14,6 +15,9 @@ pub trait ConfigProperties {
     fn merge_request_description_signature(&self) -> &str {
         ""
     }
+    fn get_cache_expiration(&self, _api_operation: ApiOperation) -> &str {
+        ""
+    }
 }
 
 #[derive(Clone, Default)]
@@ -22,6 +26,7 @@ pub struct Config {
     cache_location: String,
     preferred_assignee_username: String,
     merge_request_description_signature: String,
+    cache_expirations: HashMap<ApiOperation, String>,
 }
 
 impl Config {
@@ -49,12 +54,43 @@ impl Config {
         let merge_request_description_signature = domain_config_data
             .get("merge_request_description_signature")
             .unwrap_or(&default_merge_request_description_signature);
+        let cache_expirations = Config::cache_expirations(domain_config_data);
+
         Ok(Config {
             api_token: api_token.to_string(),
             cache_location: cache_location.to_string(),
             preferred_assignee_username: preferred_assignee_username.to_string(),
             merge_request_description_signature: merge_request_description_signature.to_string(),
+            cache_expirations,
         })
+    }
+
+    fn cache_expirations(
+        domain_config_data: &HashMap<String, String>,
+    ) -> HashMap<ApiOperation, String> {
+        let mut cache_expirations: HashMap<ApiOperation, String> = HashMap::new();
+        cache_expirations.insert(
+            ApiOperation::MergeRequest,
+            domain_config_data
+                .get("cache_api_merge_request_expiration")
+                .unwrap_or(&"".to_string())
+                .to_string(),
+        );
+        cache_expirations.insert(
+            ApiOperation::Pipeline,
+            domain_config_data
+                .get("cache_api_pipeline_expiration")
+                .unwrap_or(&"".to_string())
+                .to_string(),
+        );
+        cache_expirations.insert(
+            ApiOperation::Project,
+            domain_config_data
+                .get("cache_api_project_expiration")
+                .unwrap_or(&"".to_string())
+                .to_string(),
+        );
+        cache_expirations
     }
 
     fn parse<T: Read>(
@@ -112,6 +148,14 @@ impl ConfigProperties for Config {
     fn merge_request_description_signature(&self) -> &str {
         &self.merge_request_description_signature
     }
+
+    fn get_cache_expiration(&self, api_operation: ApiOperation) -> &str {
+        let expiration = self.cache_expirations.get(&api_operation);
+        match expiration {
+            Some(expiration) => expiration,
+            None => "",
+        }
+    }
 }
 
 impl ConfigProperties for Arc<Config> {
@@ -129,6 +173,10 @@ impl ConfigProperties for Arc<Config> {
 
     fn merge_request_description_signature(&self) -> &str {
         &self.merge_request_description_signature
+    }
+
+    fn get_cache_expiration(&self, _api_operation: ApiOperation) -> &str {
+        ""
     }
 }
 
@@ -218,5 +266,40 @@ mod test {
             "- devops team :-)",
             config.merge_request_description_signature()
         );
+    }
+
+    #[test]
+    fn test_config_cache_api_expirations() {
+        let config_data = r#"
+        github.com.api_token=1234
+        github.com.cache_location=/home/user/.config/mr_cache
+        github.com.preferred_assignee_username=jordilin
+        github.com.merge_request_description_signature=- devops team :-)
+        github.com.cache_api_merge_request_expiration=2h
+        github.com.cache_api_pipeline_expiration=1h
+        github.com.cache_api_project_expiration=3h"#;
+        let domain = "github.com";
+        let reader = std::io::Cursor::new(config_data);
+        let config = Config::new(reader, domain).unwrap();
+        assert_eq!(
+            "2h",
+            config.get_cache_expiration(ApiOperation::MergeRequest)
+        );
+        assert_eq!("1h", config.get_cache_expiration(ApiOperation::Pipeline));
+        assert_eq!("3h", config.get_cache_expiration(ApiOperation::Project));
+    }
+
+    #[test]
+    fn test_config_cache_api_expiration_default() {
+        let config_data = r#"
+        github.com.api_token=1234
+        github.com.cache_location=/home/user/.config/mr_cache
+        github.com.preferred_assignee_username=jordilin
+        github.com.merge_request_description_signature=- devops team :-)
+        "#;
+        let domain = "github.com";
+        let reader = std::io::Cursor::new(config_data);
+        let config = Config::new(reader, domain).unwrap();
+        assert_eq!("", config.get_cache_expiration(ApiOperation::MergeRequest));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub enum GRError {
     #[error("Precondition not met error: {0}")]
     PreconditionNotMet(String),
+    #[error("Configuration error: {0}")]
+    ConfigurationError(String),
 }
 
 pub trait AddContext<T, E>: Context<T, E> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub enum GRError {
     #[error("Precondition not met error: {0}")]
     PreconditionNotMet(String),
+    #[error("Time conversion error: {0}")]
+    TimeConversionError(String),
     #[error("Configuration error: {0}")]
     ConfigurationError(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use anyhow::{anyhow, Context, Result};
 use thiserror::Error;
 
@@ -12,7 +14,7 @@ pub enum GRError {
 }
 
 pub trait AddContext<T, E>: Context<T, E> {
-    fn err_context(self, msg: &str) -> Result<T, anyhow::Error>
+    fn err_context<C: Display + Send + Sync + 'static>(self, msg: C) -> Result<T, anyhow::Error>
     where
         Self: Sized,
     {

--- a/src/git.rs
+++ b/src/git.rs
@@ -51,7 +51,7 @@ pub fn current_branch(runner: &impl Runner<Response = Response>) -> Result<CmdIn
     // let cmd_params = ["git", "branch", "--show-current"];
     // Use rev-parse for older versions of git that don't support --show-current.
     let cmd_params = ["git", "rev-parse", "--abbrev-ref", "HEAD"];
-    let response = runner.run(cmd_params).err_context(&format!(
+    let response = runner.run(cmd_params).err_context(format!(
         "Failed to get current branch. Command: {}",
         cmd_params.join(" ")
     ))?;
@@ -65,7 +65,7 @@ pub fn current_branch(runner: &impl Runner<Response = Response>) -> Result<CmdIn
 /// [`CmdInfo::Ignore`].
 pub fn fetch(exec: &impl Runner) -> Result<CmdInfo> {
     let cmd_params = ["git", "fetch"];
-    exec.run(cmd_params).err_context(&format!(
+    exec.run(cmd_params).err_context(format!(
         "Failed to git fetch. Command: {}",
         cmd_params.join(" ")
     ))?;
@@ -173,7 +173,7 @@ pub fn last_commit_message(runner: &impl Runner<Response = Response>) -> Result<
 pub fn checkout(runner: &impl Runner<Response = Response>, branch: &str) -> Result<()> {
     let git_cmd = format!("git checkout origin/{} -b {}", branch, branch);
     let cmd_params = ["/bin/sh", "-c", &git_cmd];
-    runner.run(cmd_params).err_context(&format!(
+    runner.run(cmd_params).err_context(format!(
         "Failed to git checkout remote branch. Command: {}",
         cmd_params.join(" ")
     ))?;

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -230,7 +230,7 @@ impl<R: HttpRunner<Response = Response>> RemoteProject for Gitlab<R> {
             http::Request::new(self.rest_api_basepath(), http::Method::GET)
                 .with_api_operation(ApiOperation::Project);
         request.set_header("PRIVATE-TOKEN", self.api_token());
-        let response = self.runner.run(&mut request).err_context(&format!(
+        let response = self.runner.run(&mut request).err_context(format!(
             "Failed to get remote project data API URL: {}",
             self.rest_api_basepath()
         ))?;

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,5 @@
 use crate::api_defaults::REST_API_MAX_PAGES;
+use crate::api_traits::ApiOperation;
 use crate::cache::{Cache, CacheState};
 use crate::io::{HttpRunner, Response};
 use crate::Result;
@@ -103,6 +104,7 @@ pub struct Request<T> {
     headers: HashMap<String, String>,
     url: String,
     method: Method,
+    pub(crate) api_operation: Option<ApiOperation>,
 }
 
 impl<T> Request<T> {
@@ -112,7 +114,13 @@ impl<T> Request<T> {
             headers: HashMap::new(),
             url: url.to_string(),
             method,
+            api_operation: None,
         }
+    }
+
+    pub fn with_api_operation(mut self, api_operation: ApiOperation) -> Self {
+        self.api_operation = Some(api_operation);
+        self
     }
 
     pub fn with_body(mut self, body: T) -> Self {

--- a/src/http.rs
+++ b/src/http.rs
@@ -108,7 +108,7 @@ impl Resource {
     fn new(url: &str, api_operation: Option<ApiOperation>) -> Self {
         Resource {
             url: url.to_string(),
-            api_operation: api_operation,
+            api_operation,
         }
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -101,7 +101,7 @@ impl<C> Client<C> {
 
 pub struct Resource {
     pub url: String,
-    api_operation: Option<ApiOperation>,
+    pub api_operation: Option<ApiOperation>,
 }
 
 impl Resource {

--- a/src/http.rs
+++ b/src/http.rs
@@ -99,12 +99,25 @@ impl<C> Client<C> {
     }
 }
 
+pub struct Resource {
+    pub url: String,
+    api_operation: Option<ApiOperation>,
+}
+
+impl Resource {
+    fn new(url: &str, api_operation: Option<ApiOperation>) -> Self {
+        Resource {
+            url: url.to_string(),
+            api_operation: api_operation,
+        }
+    }
+}
+
 pub struct Request<T> {
     body: Option<T>,
     headers: HashMap<String, String>,
-    url: String,
     method: Method,
-    pub(crate) api_operation: Option<ApiOperation>,
+    pub resource: Resource,
 }
 
 impl<T> Request<T> {
@@ -112,15 +125,18 @@ impl<T> Request<T> {
         Request {
             body: None,
             headers: HashMap::new(),
-            url: url.to_string(),
             method,
-            api_operation: None,
+            resource: Resource::new(url, None),
         }
     }
 
     pub fn with_api_operation(mut self, api_operation: ApiOperation) -> Self {
-        self.api_operation = Some(api_operation);
+        self.resource.api_operation = Some(api_operation);
         self
+    }
+
+    pub fn api_operation(&self) -> &Option<ApiOperation> {
+        &self.resource.api_operation
     }
 
     pub fn with_body(mut self, body: T) -> Self {
@@ -137,11 +153,11 @@ impl<T> Request<T> {
     }
 
     pub fn set_url(&mut self, url: &str) {
-        self.url = url.to_string();
+        self.resource.url = url.to_string();
     }
 
     pub fn url(&self) -> &str {
-        &self.url
+        &self.resource.url
     }
 
     pub fn headers(&self) -> &HashMap<String, String> {
@@ -156,7 +172,7 @@ pub enum Method {
     PATCH,
 }
 
-impl<C: Cache> HttpRunner for Client<C> {
+impl<C: Cache<Resource>> HttpRunner for Client<C> {
     type Response = Response;
 
     fn run<T: Serialize>(&self, cmd: &mut Request<T>) -> Result<Self::Response> {
@@ -164,7 +180,7 @@ impl<C: Cache> HttpRunner for Client<C> {
             Method::GET => {
                 let mut default_response = Response::new();
                 if !self.refresh_cache {
-                    match self.cache.get(&cmd.url) {
+                    match self.cache.get(&cmd.resource) {
                         Ok(CacheState::Fresh(response)) => return Ok(response),
                         Ok(CacheState::Stale(response)) => {
                             default_response = response;
@@ -184,7 +200,7 @@ impl<C: Cache> HttpRunner for Client<C> {
                     // Not modified return the cached response.
                     return Ok(default_response);
                 }
-                self.cache.set(&cmd.url, &response).unwrap();
+                self.cache.set(&cmd.resource, &response).unwrap();
                 Ok(response)
             }
             Method::POST => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod merge_request;
 pub mod remote;
 pub mod shell;
 pub mod test;
+pub mod time;
 pub type Result<T> = anyhow::Result<T>;
 pub type Cmd<T> = Box<dyn Fn() -> Result<T> + Send + Sync>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod shell;
 pub mod test;
 pub mod time;
 pub type Result<T> = anyhow::Result<T>;
+pub type Error = anyhow::Error;
 pub type Cmd<T> = Box<dyn Fn() -> Result<T> + Send + Sync>;
 
 #[macro_use]

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 pub mod utils {
-    use crate::{config::ConfigProperties, error};
+    use crate::{api_traits::ApiOperation, config::ConfigProperties, error};
     use serde::Serialize;
 
     use crate::{
@@ -44,6 +44,7 @@ pub mod utils {
         cmd: RefCell<String>,
         headers: RefCell<HashMap<String, String>>,
         url: RefCell<String>,
+        pub api_operation: RefCell<Option<ApiOperation>>,
     }
 
     impl MockRunner {
@@ -53,6 +54,7 @@ pub mod utils {
                 cmd: RefCell::new(String::new()),
                 headers: RefCell::new(HashMap::new()),
                 url: RefCell::new(String::new()),
+                api_operation: RefCell::new(None),
             }
         }
 
@@ -97,6 +99,7 @@ pub mod utils {
         fn run<T: Serialize>(&self, cmd: &mut Request<T>) -> Result<Self::Response> {
             self.url.replace(cmd.url().to_string());
             self.headers.replace(cmd.headers().clone());
+            self.api_operation.replace(cmd.api_operation.clone());
             let response = self.responses.borrow_mut().pop().unwrap();
             match response.status() {
                 // 409 Conflict - Merge request already exists.

--- a/src/test.rs
+++ b/src/test.rs
@@ -99,7 +99,7 @@ pub mod utils {
         fn run<T: Serialize>(&self, cmd: &mut Request<T>) -> Result<Self::Response> {
             self.url.replace(cmd.url().to_string());
             self.headers.replace(cmd.headers().clone());
-            self.api_operation.replace(cmd.api_operation.clone());
+            self.api_operation.replace(cmd.api_operation().clone());
             let response = self.responses.borrow_mut().pop().unwrap();
             match response.status() {
                 // 409 Conflict - Merge request already exists.

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,6 +1,8 @@
 // Time utility functions
 
-use crate::error::GRError;
+use crate::Error;
+
+use crate::error::{self, GRError};
 use crate::Result;
 use std;
 use std::ops::{Deref, Sub};
@@ -24,7 +26,7 @@ impl Time {
 }
 
 impl TryFrom<char> for Time {
-    type Error = GRError;
+    type Error = Error;
 
     fn try_from(time: char) -> std::result::Result<Self, Self::Error> {
         match time {
@@ -32,7 +34,7 @@ impl TryFrom<char> for Time {
             'm' => Ok(Time::Minute),
             'h' => Ok(Time::Hour),
             'd' => Ok(Time::Day),
-            _ => Err(GRError::TimeConversionError(format!(
+            _ => Err(error::gen(format!(
                 "Unknown char time format: {} - valid types are s, m, h, d",
                 time
             ))),
@@ -92,9 +94,9 @@ impl TryFrom<&str> for Seconds {
     fn try_from(str_fmt: &str) -> std::result::Result<Self, Self::Error> {
         match string_to_seconds(str_fmt) {
             Ok(seconds) => Ok(seconds),
-            Err(err) => Err(GRError::ConfigurationError(format!(
-                "Cannot convert {} to seconds, caused by: {}",
-                str_fmt, err
+            Err(err) => Err(GRError::TimeConversionError(format!(
+                "Could not convert {} to time format: {}",
+                str_fmt, err,
             ))),
         }
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -32,7 +32,7 @@ impl TryFrom<char> for Time {
             'm' => Ok(Time::Minute),
             'h' => Ok(Time::Hour),
             'd' => Ok(Time::Day),
-            _ => Err(GRError::ConfigurationError(format!(
+            _ => Err(GRError::TimeConversionError(format!(
                 "Unknown char time format: {} - valid types are s, m, h, d",
                 time
             ))),
@@ -93,7 +93,7 @@ impl TryFrom<&str> for Seconds {
         match string_to_seconds(str_fmt) {
             Ok(seconds) => Ok(seconds),
             Err(err) => Err(GRError::ConfigurationError(format!(
-                "Cannot convert {} to seconds: {}",
+                "Cannot convert {} to seconds, caused by: {}",
                 str_fmt, err
             ))),
         }

--- a/src/time.rs
+++ b/src/time.rs
@@ -3,6 +3,7 @@
 use crate::error::GRError;
 use crate::Result;
 use std;
+use std::ops::{Deref, Sub};
 
 enum Time {
     Second,
@@ -39,7 +40,30 @@ impl TryFrom<char> for Time {
     }
 }
 
+#[derive(Debug, PartialEq, PartialOrd)]
 pub struct Seconds(u64);
+
+impl Seconds {
+    pub fn new(seconds: u64) -> Self {
+        Seconds(seconds)
+    }
+}
+
+impl Sub<Seconds> for Seconds {
+    type Output = Seconds;
+
+    fn sub(self, rhs: Seconds) -> Self::Output {
+        Seconds(self.0 - rhs.0)
+    }
+}
+
+impl Deref for Seconds {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// Convert a string with time format to seconds.
 /// A string with time format can be anything like:
@@ -99,6 +123,8 @@ mod tests {
             ("2 d", Seconds(172800)),
             // If no time format is specified, it defaults to seconds
             ("300", Seconds(300)),
+            // empty string is zero
+            ("", Seconds(0)),
         ];
         for (input, expected) in test_table {
             let actual = string_to_seconds(input).unwrap();

--- a/src/time.rs
+++ b/src/time.rs
@@ -70,7 +70,7 @@ impl Deref for Seconds {
 /// 1s, 2s, 2 seconds, 2 second, 2seconds, 2second, 2 s
 /// The same would apply for minutes, hours and days
 /// Processing stops at the first non-digit character
-pub fn string_to_seconds(str_fmt: &str) -> Result<Seconds> {
+fn string_to_seconds(str_fmt: &str) -> Result<Seconds> {
     let mut seconds: u64 = 0;
     for c in str_fmt.chars() {
         if c.is_digit(10) {
@@ -84,6 +84,20 @@ pub fn string_to_seconds(str_fmt: &str) -> Result<Seconds> {
         }
     }
     Ok(Seconds(seconds))
+}
+
+impl TryFrom<&str> for Seconds {
+    type Error = GRError;
+
+    fn try_from(str_fmt: &str) -> std::result::Result<Self, Self::Error> {
+        match string_to_seconds(str_fmt) {
+            Ok(seconds) => Ok(seconds),
+            Err(err) => Err(GRError::ConfigurationError(format!(
+                "Cannot convert {} to seconds: {}",
+                str_fmt, err
+            ))),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,114 @@
+// Time utility functions
+
+use crate::error::GRError;
+use crate::Result;
+use std;
+
+enum Time {
+    Second,
+    Minute,
+    Hour,
+    Day,
+}
+
+impl Time {
+    fn to_seconds(&self) -> u64 {
+        match self {
+            Time::Second => 1,
+            Time::Minute => 60,
+            Time::Hour => 3600,
+            Time::Day => 86400,
+        }
+    }
+}
+
+impl TryFrom<char> for Time {
+    type Error = GRError;
+
+    fn try_from(time: char) -> std::result::Result<Self, Self::Error> {
+        match time {
+            's' => Ok(Time::Second),
+            'm' => Ok(Time::Minute),
+            'h' => Ok(Time::Hour),
+            'd' => Ok(Time::Day),
+            _ => Err(GRError::ConfigurationError(format!(
+                "Unknown char time format: {} - valid types are s, m, h, d",
+                time
+            ))),
+        }
+    }
+}
+
+pub struct Seconds(u64);
+
+/// Convert a string with time format to seconds.
+/// A string with time format can be anything like:
+/// 1s, 2s, 2 seconds, 2 second, 2seconds, 2second, 2 s
+/// The same would apply for minutes, hours and days
+/// Processing stops at the first non-digit character
+pub fn string_to_seconds(str_fmt: &str) -> Result<Seconds> {
+    let mut seconds: u64 = 0;
+    for c in str_fmt.chars() {
+        if c.is_digit(10) {
+            seconds = seconds * 10 + c.to_digit(10).unwrap() as u64;
+        } else {
+            if c.is_whitespace() {
+                continue;
+            }
+            seconds = seconds * Time::try_from(c)?.to_seconds();
+            break;
+        }
+    }
+    Ok(Seconds(seconds))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_time_formatted_string_to_seconds() {
+        let test_table = vec![
+            ("1s", Seconds(1)),
+            ("2s", Seconds(2)),
+            ("2 seconds", Seconds(2)),
+            ("2 second", Seconds(2)),
+            ("2seconds", Seconds(2)),
+            ("2second", Seconds(2)),
+            ("2 s", Seconds(2)),
+            ("1m", Seconds(60)),
+            ("2m", Seconds(120)),
+            ("2 minutes", Seconds(120)),
+            ("2 minute", Seconds(120)),
+            ("2minutes", Seconds(120)),
+            ("2minute", Seconds(120)),
+            ("2 m", Seconds(120)),
+            ("1h", Seconds(3600)),
+            ("2h", Seconds(7200)),
+            ("2 hours", Seconds(7200)),
+            ("2 hour", Seconds(7200)),
+            ("2hours", Seconds(7200)),
+            ("2hour", Seconds(7200)),
+            ("2 h", Seconds(7200)),
+            ("1d", Seconds(86400)),
+            ("2d", Seconds(172800)),
+            ("2 days", Seconds(172800)),
+            ("2 day", Seconds(172800)),
+            ("2days", Seconds(172800)),
+            ("2day", Seconds(172800)),
+            ("2 d", Seconds(172800)),
+            // If no time format is specified, it defaults to seconds
+            ("300", Seconds(300)),
+        ];
+        for (input, expected) in test_table {
+            let actual = string_to_seconds(input).unwrap();
+            assert_eq!(expected.0, actual.0);
+        }
+    }
+
+    #[test]
+    fn test_cannot_convert_time_formatted_string_to_seconds() {
+        let input_err = "2x"; // user meant 2d and typed 2x
+        assert!(string_to_seconds(input_err).is_err());
+    }
+}


### PR DESCRIPTION
Provides three new configuration properties for how long we can cache a
specific API.

- `<domain>`.cache_api_merge_request_expiration: List merge_requests, get a
  merge request, etc... Any read operation involving merge/pull requests.
- `<domain>`.cache_api_project_expiration: Get project metadata, members of a
  project. This information does not change often, so a long expiration is fine.
- `<domain>`.cache_api_pipeline_expiration: List pipelines, get a pipeline, etc...