### PR TITLE
max pages based on API

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,24 @@ gitlab.com.api_token=<your api token>
 gitlab.com.cache_location=/home/<youruser>/.cache/gr
 gitlab.com.preferred_assignee_username=<your username>
 gitlab.com.merge_request_description_signature=<your signature, @someone, etc...>
+
+## Cache expiration configuration
+
 # Expire read merge requests in 5 minutes
 gitlab.com.cache_api_merge_request_expiration=5m
 # Expire read project metadata, members of a project in 5 days
 gitlab.com.cache_api_project_expiration=5d
 # Pipelines are read often, change often, so expire immediately.
 gitlab.com.cache_api_pipeline_expiration=0s
+
+## Max pages configuration
+
+# Get up to 10 pages of merge requests when listing
+gitlab.com.max_pages_api_merge_request=10
+# Get up to 5 pages of project metadata, members of a project when listing
+gitlab.com.max_pages_api_project=5
+# Get up to 10 pages of pipelines when listing
+gitlab.com.max_pages_api_pipeline=10
 
 
 # Github
@@ -101,6 +113,18 @@ for minutes, `h` for hours, `d` for days. For example, `5m` means 5 minutes,
 
 If omitted, the default is immediate expiration, so read operations are always
 pulled from the remote.
+
+When listing merge requests, projects, pipelines, etc... the tool will fetch up
+to max pages. We can control this per API as follows:
+
+- `<domain>`.max_pages_api_merge_request: List merge_requests, get a
+  merge request, etc... Any read operation involving merge/pull requests.
+- `<domain>`.max_pages_api_project: Get project metadata, members of a project.
+- `<domain>`.max_pages_api_pipeline: List pipelines, get a pipeline, etc...
+
+If omitted, the default global number of pages for all APIs is 10. This is to
+avoid fetching too much data when the amount of information is large.
+The default number of results per page for Gitlab is 20 and for Github is 30.
 
 ### Example open a merge/pull request
 

--- a/src/api_defaults.rs
+++ b/src/api_defaults.rs
@@ -3,4 +3,4 @@
 // Github 30
 // Gitlab 20
 // Max number of pages to pull from the remote.
-pub const REST_API_MAX_PAGES: u32 = 2;
+pub const REST_API_MAX_PAGES: u32 = 10;

--- a/src/browse.rs
+++ b/src/browse.rs
@@ -1,9 +1,16 @@
+use std::sync::Arc;
+
 use crate::cli::BrowseOptions;
 use crate::config::Config;
 use crate::remote;
 use crate::Result;
 
-pub fn execute(options: BrowseOptions, config: Config, domain: String, path: String) -> Result<()> {
+pub fn execute(
+    options: BrowseOptions,
+    config: Arc<Config>,
+    domain: String,
+    path: String,
+) -> Result<()> {
     match options {
         BrowseOptions::Repo => {
             // No need to contact the remote object, domain and path already

--- a/src/cicd.rs
+++ b/src/cicd.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::cli::PipelineOptions;
 use crate::config::Config;
 use crate::remote;
@@ -5,7 +7,7 @@ use crate::Result;
 
 pub fn execute(
     options: PipelineOptions,
-    config: Config,
+    config: Arc<Config>,
     domain: String,
     path: String,
 ) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,15 +209,19 @@ impl ConfigProperties for Arc<Config> {
     }
 
     fn preferred_assignee_username(&self) -> &str {
-        &self.preferred_assignee_username
+        self.as_ref().preferred_assignee_username()
     }
 
     fn merge_request_description_signature(&self) -> &str {
-        &self.merge_request_description_signature
+        self.as_ref().merge_request_description_signature()
     }
 
-    fn get_cache_expiration(&self, _api_operation: &ApiOperation) -> &str {
-        ""
+    fn get_cache_expiration(&self, api_operation: &ApiOperation) -> &str {
+        self.as_ref().get_cache_expiration(api_operation)
+    }
+
+    fn get_max_pages(&self, api_operation: &ApiOperation) -> u32 {
+        self.as_ref().get_max_pages(api_operation)
     }
 }
 
@@ -235,7 +239,7 @@ mod test {
         "#;
         let domain = "gitlab.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!("1234", config.api_token());
     }
 
@@ -251,7 +255,7 @@ mod test {
         "#;
         let domain = "gitlab.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!("1234", config.api_token());
     }
 
@@ -289,7 +293,7 @@ mod test {
         github.com.preferred_assignee_username=jordilin"#;
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!("jordilin", config.preferred_assignee_username());
     }
 
@@ -302,7 +306,7 @@ mod test {
         github.com.merge_request_description_signature=- devops team :-)"#;
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!(
             "- devops team :-)",
             config.merge_request_description_signature()
@@ -321,7 +325,7 @@ mod test {
         github.com.cache_api_project_expiration=3h"#;
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!(
             "2h",
             config.get_cache_expiration(&ApiOperation::MergeRequest)
@@ -340,7 +344,7 @@ mod test {
         "#;
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!("", config.get_cache_expiration(&ApiOperation::MergeRequest));
     }
 
@@ -354,7 +358,7 @@ mod test {
         "#;
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!(2, config.get_max_pages(&ApiOperation::MergeRequest));
     }
 
@@ -367,7 +371,7 @@ mod test {
         "#;
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!(
             REST_API_MAX_PAGES,
             config.get_max_pages(&ApiOperation::MergeRequest)
@@ -384,7 +388,7 @@ mod test {
         "#;
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!(4, config.get_max_pages(&ApiOperation::Pipeline));
     }
 
@@ -396,7 +400,7 @@ mod test {
         github.com.preferred_assignee_username=jordilin"#;
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!(
             REST_API_MAX_PAGES,
             config.get_max_pages(&ApiOperation::Pipeline)
@@ -413,7 +417,7 @@ mod test {
         "#;
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!(6, config.get_max_pages(&ApiOperation::Project));
     }
 
@@ -425,7 +429,7 @@ mod test {
         github.com.preferred_assignee_username=jordilin"#;
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
-        let config = Config::new(reader, domain).unwrap();
+        let config = Arc::new(Config::new(reader, domain).unwrap());
         assert_eq!(
             REST_API_MAX_PAGES,
             config.get_max_pages(&ApiOperation::Project)

--- a/src/http.rs
+++ b/src/http.rs
@@ -379,23 +379,6 @@ mod test {
     }
 
     #[test]
-    fn test_paginator_limits_to_max_pages_default() {
-        let mut responses = Vec::new();
-        for _ in 0..15 {
-            let response = response_with_next_page();
-            responses.push(response);
-        }
-        let last_response = response_with_last_page();
-        responses.push(last_response);
-        responses.reverse();
-        let client = Arc::new(MockRunner::new(responses));
-        let request: Request<()> = Request::new("http://localhost", Method::GET);
-        let paginator = Paginator::new(&client, request, "http://localhost");
-        let responses = paginator.collect::<Vec<Result<Response>>>();
-        assert_eq!(10, responses.len());
-    }
-
-    #[test]
     fn test_client_get_api_max_pages() {
         let config = ConfigMock::new(1);
         let runner = Client::new(cache::NoCache, config, false);
@@ -420,8 +403,7 @@ mod test {
     }
 
     #[test]
-    fn test_if_api_max_pages_larger_than_global_rest_api_max_pages_then_rest_api_max_pages_is_used()
-    {
+    fn test_paginator_limits_to_max_pages_default() {
         let api_max_pages = REST_API_MAX_PAGES + 5;
         let mut responses = Vec::new();
         for _ in 0..api_max_pages {

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,6 +1,7 @@
 use crate::api_defaults::REST_API_MAX_PAGES;
 use crate::api_traits::ApiOperation;
 use crate::cache::{Cache, CacheState};
+use crate::config::ConfigProperties;
 use crate::io::{HttpRunner, Response};
 use crate::Result;
 use serde::Serialize;
@@ -8,16 +9,18 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use ureq::Error;
 
-pub struct Client<C> {
+pub struct Client<C, D> {
     cache: C,
+    config: D,
     refresh_cache: bool,
 }
 
-impl<C> Client<C> {
-    pub fn new(cache: C, refresh_cache: bool) -> Self {
+impl<C, D> Client<C, D> {
+    pub fn new(cache: C, config: D, refresh_cache: bool) -> Self {
         Client {
             cache,
             refresh_cache,
+            config,
         }
     }
 
@@ -172,7 +175,7 @@ pub enum Method {
     PATCH,
 }
 
-impl<C: Cache<Resource>> HttpRunner for Client<C> {
+impl<C: Cache<Resource>, D: ConfigProperties> HttpRunner for Client<C, D> {
     type Response = Response;
 
     fn run<T: Serialize>(&self, cmd: &mut Request<T>) -> Result<Self::Response> {

--- a/src/io.rs
+++ b/src/io.rs
@@ -18,9 +18,8 @@ pub trait Runner {
 pub trait HttpRunner {
     type Response;
     fn run<T: Serialize>(&self, cmd: &mut Request<T>) -> Result<Self::Response>;
-    // When pagination is being used, this will be called to determine if we
-    // should stop paging based on the type of request being made.
-    // fn stop_paging<T: Serialize>(&self, cmd: &Request<T>) -> bool;
+    /// Return the number of API MAX PAGES allowed for the given Request.
+    fn api_max_pages<T: Serialize>(&self, cmd: &Request<T>) -> u32;
 }
 
 #[derive(Debug)]

--- a/src/io.rs
+++ b/src/io.rs
@@ -18,6 +18,9 @@ pub trait Runner {
 pub trait HttpRunner {
     type Response;
     fn run<T: Serialize>(&self, cmd: &mut Request<T>) -> Result<Self::Response>;
+    // When pagination is being used, this will be called to determine if we
+    // should stop paging based on the type of request being made.
+    // fn stop_paging<T: Serialize>(&self, cmd: &Request<T>) -> bool;
 }
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::Path};
+use std::{fs::File, path::Path, sync::Arc};
 
 use gr::{
     browse, cicd,
@@ -21,12 +21,12 @@ fn main() -> Result<()> {
     let CmdInfo::RemoteUrl { domain, path } = git::remote_url(&Shell)? else {
         return Err(error::gen("No remote url found. Please set a remote url."));
     };
-    let config = gr::config::Config::new(f, &domain).expect("Unable to read config");
+    let config = Arc::new(gr::config::Config::new(f, &domain).expect("Unable to read config"));
     match cli_options {
         CliOptions::MergeRequest(options) => merge_request::execute(options, config, domain, path),
         CliOptions::Browse(options) => {
             // Use default config for browsing - does not require auth.
-            let config = gr::config::Config::default();
+            let config = Arc::new(gr::config::Config::default());
             browse::execute(options, config, domain, path)
         }
         CliOptions::Pipeline(options) => cicd::execute(options, config, domain, path),

--- a/src/merge_request.rs
+++ b/src/merge_request.rs
@@ -37,14 +37,7 @@ pub fn execute(
             refresh_cache,
         } => {
             let remote = remote::get(domain, path, config.clone(), refresh_cache)?;
-            open(
-                remote,
-                Arc::new(config),
-                title,
-                description,
-                target_branch,
-                noprompt,
-            )
+            open(remote, config, title, description, target_branch, noprompt)
         }
         MergeRequestOptions::List {
             state,

--- a/src/merge_request.rs
+++ b/src/merge_request.rs
@@ -24,7 +24,7 @@ use crate::Result;
 
 pub fn execute(
     options: MergeRequestOptions,
-    config: Config,
+    config: Arc<Config>,
     domain: String,
     path: String,
 ) -> Result<()> {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -230,11 +230,12 @@ impl Display for Pipeline {
 pub fn get(
     domain: String,
     path: String,
-    config: Config,
+    config: Arc<Config>,
     refresh_cache: bool,
 ) -> Result<Arc<dyn Remote>> {
     let runner = Arc::new(http::Client::new(
         FileCache::new(config.clone()),
+        config.clone(),
         refresh_cache,
     ));
     let github_domain_regex = regex::Regex::new(r"^github").unwrap();


### PR DESCRIPTION
Allow to specify the maximum number of paged results based on API. If not
specified it defaults to 10.