### PR TITLE
Handle ratelimit headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ gitlab.com.max_pages_api_project=5
 # Get up to 10 pages of pipelines when listing
 gitlab.com.max_pages_api_pipeline=10
 
+# Rate limit remaining threshold. Threshold by which the tool will stop
+# processing requests. Defaults to 10 if not provided. The remote has a counter
+# that decreases with each request. When we reach this threshold we stop for safety.
+# When it reaches 0 the remote will throw errors.
+
+gitlab.com.rate_limit_remaining_threshold=10
 
 # Github
 github.com.api_token=<your api token>

--- a/src/api_defaults.rs
+++ b/src/api_defaults.rs
@@ -8,3 +8,7 @@ pub const REST_API_MAX_PAGES: u32 = 10;
 // Number of requests remaining threshold. If we reach, we stop for precaution
 // before we reach 0.
 pub const RATE_LIMIT_REMAINING_THRESHOLD: u32 = 10;
+
+// most limiting Github 5000/60 = 83.33 requests per minute. Round
+// up to 80.
+pub const DEFAULT_NUMBER_REQUESTS_MINUTE: u32 = 80;

--- a/src/api_defaults.rs
+++ b/src/api_defaults.rs
@@ -4,3 +4,7 @@
 // Gitlab 20
 // Max number of pages to pull from the remote.
 pub const REST_API_MAX_PAGES: u32 = 10;
+
+// Number of requests remaining threshold. If we reach, we stop for precaution
+// before we reach 0.
+pub const RATE_LIMIT_REMAINING_THRESHOLD: u32 = 10;

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ pub enum GRError {
     OperationNotSupported(String),
     #[error("RateLimit exceeded: {0}")]
     RateLimitExceeded(String),
+    #[error("Application error: {0}")]
+    ApplicationError(String),
 }
 
 pub trait AddContext<T, E>: Context<T, E> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,8 @@ pub enum GRError {
     ConfigurationError(String),
     #[error("Operation not supported for this resource: {0}")]
     OperationNotSupported(String),
+    #[error("RateLimit exceeded: {0}")]
+    RateLimitExceeded(String),
 }
 
 pub trait AddContext<T, E>: Context<T, E> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -111,7 +111,7 @@ impl<C, D> Client<C, D> {
 }
 
 impl<C, D: ConfigProperties> Client<C, D> {
-    fn handle_rate_limit(&self, response: &mut Response) -> Result<()> {
+    fn handle_rate_limit(&self, response: &Response) -> Result<()> {
         if let Some(headers) = response.get_ratelimit_headers() {
             if headers.remaining <= self.config.rate_limit_remaining_threshold() {
                 return Err(error::GRError::RateLimitExceeded(
@@ -283,7 +283,7 @@ impl<C: Cache<Resource>, D: ConfigProperties> HttpRunner for Client<C, D> {
                     cmd.set_header("If-None-Match", etag);
                 }
                 // If status is 304, then we need to return the cached response.
-                let mut response = self.get(cmd)?;
+                let response = self.get(cmd)?;
                 if response.status() == 304 {
                     // Update cache with latest headers. This effectively
                     // refreshes the cache and we won't hit this until per api
@@ -292,23 +292,23 @@ impl<C: Cache<Resource>, D: ConfigProperties> HttpRunner for Client<C, D> {
                         .update(&cmd.resource, &response, &ResponseField::Headers)?;
                     return Ok(default_response);
                 }
-                self.handle_rate_limit(&mut response)?;
+                self.handle_rate_limit(&response)?;
                 self.cache.set(&cmd.resource, &response).unwrap();
                 Ok(response)
             }
             Method::POST => {
-                let mut response = self.post(cmd)?;
-                self.handle_rate_limit(&mut response)?;
+                let response = self.post(cmd)?;
+                self.handle_rate_limit(&response)?;
                 Ok(response)
             }
             Method::PATCH => {
-                let mut response = self.patch(cmd)?;
-                self.handle_rate_limit(&mut response)?;
+                let response = self.patch(cmd)?;
+                self.handle_rate_limit(&response)?;
                 Ok(response)
             }
             Method::PUT => {
-                let mut response = self.put(cmd)?;
-                self.handle_rate_limit(&mut response)?;
+                let response = self.put(cmd)?;
+                self.handle_rate_limit(&response)?;
                 Ok(response)
             }
         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,26 +1,34 @@
 use crate::api_traits::ApiOperation;
 use crate::cache::{Cache, CacheState};
 use crate::config::ConfigProperties;
-use crate::error;
 use crate::io::{HttpRunner, Response, ResponseField};
+use crate::time::{now_epoch_seconds, Seconds};
 use crate::Result;
+use crate::{api_defaults, error};
 use serde::Serialize;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use ureq::Error;
 
 pub struct Client<C, D> {
     cache: C,
     config: D,
     refresh_cache: bool,
+    time_to_ratelimit_reset: Mutex<Seconds>,
+    remaining_requests: Mutex<u32>,
 }
 
+// TODO: provide builder pattern for Client.
 impl<C, D> Client<C, D> {
     pub fn new(cache: C, config: D, refresh_cache: bool) -> Self {
+        let remaining_requests = Mutex::new(api_defaults::DEFAULT_NUMBER_REQUESTS_MINUTE);
+        let time_to_ratelimit_reset = Mutex::new(now_epoch_seconds() + Seconds::new(60));
         Client {
             cache,
             refresh_cache,
             config,
+            time_to_ratelimit_reset,
+            remaining_requests,
         }
     }
 
@@ -104,15 +112,79 @@ impl<C, D> Client<C, D> {
 
 impl<C, D: ConfigProperties> Client<C, D> {
     fn handle_rate_limit(&self, response: &mut Response) -> Result<()> {
-        let headers = response.get_ratelimit_headers();
-        if headers.remaining <= self.config.rate_limit_remaining_threshold() {
-            return Err(error::GRError::RateLimitExceeded(
-                "Rate limit threshold reached".to_string(),
+        if let Some(headers) = response.get_ratelimit_headers() {
+            if headers.remaining <= self.config.rate_limit_remaining_threshold() {
+                return Err(error::GRError::RateLimitExceeded(
+                    "Rate limit threshold reached".to_string(),
+                )
+                .into());
+            }
+            Ok(())
+        } else {
+            // The remote does not provide rate limit headers, so we apply our
+            // defaults for safety. Official github.com and gitlab.com do, so
+            // that could be an internal/dev, etc... instance setup without rate
+            // limits.
+            default_rate_limit_handler(
+                &self.config,
+                &self.time_to_ratelimit_reset,
+                &self.remaining_requests,
+                now_epoch_seconds,
             )
+        }
+    }
+}
+
+fn default_rate_limit_handler(
+    config: &impl ConfigProperties,
+    time_to_ratelimit_reset: &Mutex<Seconds>,
+    remaining_requests: &Mutex<u32>,
+    now_epoch_seconds: fn() -> Seconds,
+) -> Result<()> {
+    // bail if we are below the security threshold for remaining requests
+
+    if let Ok(remaining_requests) = remaining_requests.lock() {
+        if *remaining_requests <= config.rate_limit_remaining_threshold() {
+            let time_to_ratelimit_reset =
+                *time_to_ratelimit_reset.lock().unwrap() - now_epoch_seconds();
+            return Err(error::GRError::RateLimitExceeded(format!(
+                "Remote does not provide rate limit headers, \
+                            so the default rate limit of {} per minute has been \
+                            exceeded. Try again in {} seconds",
+                api_defaults::DEFAULT_NUMBER_REQUESTS_MINUTE,
+                time_to_ratelimit_reset
+            ))
             .into());
         }
-        Ok(())
+    } else {
+        return Err(error::GRError::ApplicationError(
+            "http module rate limiting - Cannot read remaining \
+                    http requests"
+                .to_string(),
+        )
+        .into());
     }
+
+    if let Ok(mut remaining_requests) = remaining_requests.lock() {
+        // if elapsed time is greater than 60 seconds, then reset
+        // remaining requests to default
+        let current_time = now_epoch_seconds();
+        let mut time_to_reset = time_to_ratelimit_reset.lock().unwrap();
+        if current_time > *time_to_reset {
+            *remaining_requests = api_defaults::DEFAULT_NUMBER_REQUESTS_MINUTE;
+            *time_to_reset = current_time + Seconds::new(60);
+        }
+        *remaining_requests -= 1;
+    } else {
+        return Err(error::GRError::ApplicationError(
+            "http module rate limiting - Cannot decrease counter \
+                        number of requests pending"
+                .to_string(),
+        )
+        .into());
+    }
+
+    Ok(())
 }
 
 pub struct Resource {
@@ -456,5 +528,73 @@ mod test {
         let mut response = Response::new().with_status(200).with_headers(headers);
         let client = Client::new(cache::NoCache, ConfigMock::new(1), false);
         assert!(client.handle_rate_limit(&mut response).is_ok());
+    }
+
+    fn epoch_seconds_now_mock(secs: u64) -> Seconds {
+        Seconds::new(secs)
+    }
+
+    #[test]
+    fn test_remaining_requests_below_threshold_all_fail() {
+        // remaining requests - below threshold of 10 (api_defaults)
+        let remaining_requests = Arc::new(Mutex::new(4));
+        // 10 seconds before we reset counter to 80 (api_defaults)
+        let time_to_ratelimit_reset = Arc::new(Mutex::new(Seconds::new(10)));
+        let now = || -> Seconds { epoch_seconds_now_mock(1) };
+        let config = Arc::new(ConfigMock::new(1));
+
+        // counter will never get reset - all requests will fail
+        let mut threads = Vec::new();
+        for _ in 0..10 {
+            let remaining_requests = remaining_requests.clone();
+            let time_to_ratelimit_reset = time_to_ratelimit_reset.clone();
+            let config = config.clone();
+            threads.push(std::thread::spawn(move || {
+                let result = default_rate_limit_handler(
+                    &config,
+                    &time_to_ratelimit_reset,
+                    &remaining_requests,
+                    now,
+                );
+                assert!(result.is_err());
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn test_time_to_reset_achieved_resets_counter_all_ok() {
+        // one remaining request before we hit threshold
+        let remaining_requests = Arc::new(Mutex::new(11));
+        let time_to_ratelimit_reset = Arc::new(Mutex::new(Seconds::new(1)));
+        // now > time_to_ratelimit_reset - counter will be reset to 80
+        let now = || -> Seconds { epoch_seconds_now_mock(2) };
+        let config = Arc::new(ConfigMock::new(1));
+
+        let mut threads = Vec::new();
+        // 70 parallel requests - remaining 11.
+        // On first request, will reset total number to 81, then decrease by 1.\
+        // having 80 left to process with a threshold of 10, then the remaining
+        // 69 will be processed. Time to reset will be set to 62
+        // If we had 71, then the last one would fail.
+        for _ in 0..70 {
+            let remaining_requests = remaining_requests.clone();
+            let time_to_ratelimit_reset = time_to_ratelimit_reset.clone();
+            let config = config.clone();
+            threads.push(std::thread::spawn(move || {
+                let result = default_rate_limit_handler(
+                    &config,
+                    &time_to_ratelimit_reset,
+                    &remaining_requests,
+                    now,
+                );
+                assert!(result.is_ok());
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,9 +1,9 @@
 use crate::api_traits::ApiOperation;
 use crate::cache::{Cache, CacheState};
 use crate::config::ConfigProperties;
+use crate::error;
 use crate::io::{HttpRunner, Response, ResponseField};
 use crate::Result;
-use crate::{api_defaults, error};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,7 @@
 use crate::{
     http::Request,
     remote::{Member, MergeRequestResponse, Project},
+    time::{now_epoch_seconds, Seconds},
     Result,
 };
 use regex::Regex;
@@ -46,6 +47,9 @@ pub struct Response {
     /// Optional headers. Mostly used by HTTP downstream HTTP responses
     pub(crate) headers: Option<HashMap<String, String>>,
     link_header_processor: fn(&str) -> PageHeader,
+    /// Default time in epoch seconds when the ratelimit is reset.
+    time_to_ratelimit_reset: Seconds,
+    remaining_requests: u32,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -62,6 +66,10 @@ impl Response {
             body: String::new(),
             headers: None,
             link_header_processor: parse_link_headers,
+            time_to_ratelimit_reset: now_epoch_seconds() + Seconds::new(60),
+            // most limiting Github 5000/60 = 83.33 requests per minute. Round
+            // up to 80.
+            remaining_requests: 80,
         }
     }
 
@@ -100,6 +108,52 @@ impl Response {
             }
         }
         None
+    }
+
+    // Defaults:
+    // https://docs.gitlab.com/ee/user/gitlab_com/index.html#gitlabcom-specific-rate-limits
+    // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-authenticated-users
+
+    // Github 5000 requests per hour for authenticated users
+    // Gitlab 2000 requests per minute for authenticated users
+    // Most limiting Github 5000/60 = 83.33 requests per minute
+
+    pub fn get_ratelimit_headers(&mut self) -> RateLimitHeader {
+        // defaults if not provided by the remote.
+        self.remaining_requests = self.remaining_requests - 1;
+        let mut ratelimit_header =
+            RateLimitHeader::new(self.remaining_requests, self.time_to_ratelimit_reset);
+
+        // process remote headers and patch the defaults accordingly
+        if let Some(headers) = &self.headers {
+            if let Some(github_remaining) = headers.get(GITHUB_RATELIMIT_REMAINING) {
+                ratelimit_header.remaining = github_remaining
+                    .parse::<u32>()
+                    .unwrap_or(self.remaining_requests);
+                if let Some(github_reset) = headers.get(GITHUB_RATELIMIT_RESET) {
+                    ratelimit_header.reset = Seconds::new(
+                        github_reset
+                            .parse::<u64>()
+                            .unwrap_or(*self.time_to_ratelimit_reset),
+                    );
+                }
+                return ratelimit_header;
+            }
+            if let Some(gitlab_remaining) = headers.get(GITLAB_RATELIMIT_REMAINING) {
+                ratelimit_header.remaining = gitlab_remaining
+                    .parse::<u32>()
+                    .unwrap_or(self.remaining_requests);
+                if let Some(gitlab_reset) = headers.get(GITLAB_RATELIMIT_RESET) {
+                    ratelimit_header.reset = Seconds::new(
+                        gitlab_reset
+                            .parse::<u64>()
+                            .unwrap_or(*self.time_to_ratelimit_reset),
+                    );
+                }
+                return ratelimit_header;
+            }
+        }
+        ratelimit_header
     }
 
     pub fn get_etag(&self) -> Option<&str> {
@@ -187,5 +241,69 @@ impl Page {
             url: url.to_string(),
             number,
         }
+    }
+}
+
+// https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
+
+pub const GITHUB_RATELIMIT_REMAINING: &str = "x-ratelimit-remaining";
+pub const GITHUB_RATELIMIT_RESET: &str = "x-ratelimit-reset";
+
+// https://docs.gitlab.com/ee/administration/settings/user_and_ip_rate_limits.html
+
+pub const GITLAB_RATELIMIT_REMAINING: &str = "RateLimit-Remaining";
+pub const GITLAB_RATELIMIT_RESET: &str = "RateLimit-Reset";
+
+/// Unifies the different ratelimit headers available from the different remotes.
+/// Github API ratelimit headers:
+/// remaining: x-ratelimit-remaining
+/// reset: x-ratelimit-reset
+/// Gitlab API ratelimit headers:
+/// remaining: RateLimit-Remaining
+/// reset: RateLimit-Reset
+#[derive(Clone, Debug)]
+pub struct RateLimitHeader {
+    // The number of requests remaining in the current rate limit window.
+    pub remaining: u32,
+    // Unix time-formatted time when the request quota is reset.
+    pub reset: Seconds,
+}
+
+impl RateLimitHeader {
+    pub fn new(remaining: u32, reset: Seconds) -> Self {
+        RateLimitHeader { remaining, reset }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get_rate_limit_headers_github() {
+        let body = "responsebody";
+        let mut headers = HashMap::new();
+        headers.insert("x-ratelimit-remaining".to_string(), "30".to_string());
+        headers.insert("x-ratelimit-reset".to_string(), "1658602270".to_string());
+        let mut response = Response::new()
+            .with_body(body.to_string())
+            .with_headers(headers);
+        let ratelimit_headers = response.get_ratelimit_headers();
+        assert_eq!(30, ratelimit_headers.remaining);
+        assert_eq!(Seconds::new(1658602270), ratelimit_headers.reset);
+    }
+
+    #[test]
+    fn test_get_rate_limit_headers_gitlab() {
+        let body = "responsebody";
+        let mut headers = HashMap::new();
+        headers.insert("RateLimit-Remaining".to_string(), "30".to_string());
+        headers.insert("RateLimit-Reset".to_string(), "1658602270".to_string());
+        let mut response = Response::new()
+            .with_body(body.to_string())
+            .with_headers(headers);
+        let ratelimit_headers = response.get_ratelimit_headers();
+        assert_eq!(30, ratelimit_headers.remaining);
+        assert_eq!(Seconds::new(1658602270), ratelimit_headers.reset);
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -118,7 +118,7 @@ impl Response {
     // Gitlab 2000 requests per minute for authenticated users
     // Most limiting Github 5000/60 = 83.33 requests per minute
 
-    pub fn get_ratelimit_headers(&mut self) -> Option<RateLimitHeader> {
+    pub fn get_ratelimit_headers(&self) -> Option<RateLimitHeader> {
         let mut ratelimit_header = RateLimitHeader::default();
 
         // process remote headers and patch the defaults accordingly
@@ -285,7 +285,7 @@ mod test {
         let mut headers = HashMap::new();
         headers.insert("x-ratelimit-remaining".to_string(), "30".to_string());
         headers.insert("x-ratelimit-reset".to_string(), "1658602270".to_string());
-        let mut response = Response::new()
+        let response = Response::new()
             .with_body(body.to_string())
             .with_headers(headers);
         let ratelimit_headers = response.get_ratelimit_headers().unwrap();
@@ -299,7 +299,7 @@ mod test {
         let mut headers = HashMap::new();
         headers.insert("ratelimit-remaining".to_string(), "30".to_string());
         headers.insert("ratelimit-reset".to_string(), "1658602270".to_string());
-        let mut response = Response::new()
+        let response = Response::new()
             .with_body(body.to_string())
             .with_headers(headers);
         let ratelimit_headers = response.get_ratelimit_headers().unwrap();
@@ -313,7 +313,7 @@ mod test {
         let mut headers = HashMap::new();
         headers.insert("RateLimit-remaining".to_string(), "30".to_string());
         headers.insert("rateLimit-reset".to_string(), "1658602270".to_string());
-        let mut response = Response::new()
+        let response = Response::new()
             .with_body(body.to_string())
             .with_headers(headers);
         let ratelimit_headers = response.get_ratelimit_headers();

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,6 +10,7 @@ pub mod utils {
         io::{HttpRunner, Response, Runner},
         Result,
     };
+    use std::sync::Arc;
     use std::{
         cell::{Ref, RefCell},
         collections::HashMap,
@@ -160,6 +161,18 @@ pub mod utils {
             ConfigMock {
                 max_pages: REST_API_MAX_PAGES,
             }
+        }
+    }
+
+    impl ConfigProperties for Arc<ConfigMock> {
+        fn api_token(&self) -> &str {
+            "1234"
+        }
+        fn cache_location(&self) -> &str {
+            ""
+        }
+        fn get_max_pages(&self, _api_operation: &ApiOperation) -> u32 {
+            self.as_ref().max_pages
         }
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,7 +5,7 @@ use crate::Error;
 use crate::error::{self, GRError};
 use crate::Result;
 use std;
-use std::ops::{Deref, Sub};
+use std::ops::{Add, Deref, Sub};
 
 enum Time {
     Second,
@@ -42,7 +42,15 @@ impl TryFrom<char> for Time {
     }
 }
 
-#[derive(Debug, PartialEq, PartialOrd)]
+pub fn now_epoch_seconds() -> Seconds {
+    let now_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    Seconds(now_epoch)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Seconds(u64);
 
 impl Seconds {
@@ -56,6 +64,14 @@ impl Sub<Seconds> for Seconds {
 
     fn sub(self, rhs: Seconds) -> Self::Output {
         Seconds(self.0 - rhs.0)
+    }
+}
+
+impl Add<Seconds> for Seconds {
+    type Output = Seconds;
+
+    fn add(self, rhs: Seconds) -> Self::Output {
+        Seconds(self.0 + rhs.0)
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,6 +5,7 @@ use crate::Error;
 use crate::error::{self, GRError};
 use crate::Result;
 use std;
+use std::fmt::{Display, Formatter};
 use std::ops::{Add, Deref, Sub};
 
 enum Time {
@@ -50,7 +51,7 @@ pub fn now_epoch_seconds() -> Seconds {
     Seconds(now_epoch)
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
 pub struct Seconds(u64);
 
 impl Seconds {
@@ -80,6 +81,12 @@ impl Deref for Seconds {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Display for Seconds {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
If the remote does not provide headers for rate limiting, then our
client can keep track of the number of requests being made to the
remote. Error if we exceed the default of 80 requests in a single
session.