### PR TITLE
Generate remote with specific trait

### DIFF
--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -53,3 +53,15 @@ impl Display for ApiOperation {
 }
 
 pub trait Remote: RemoteProject + MergeRequest + Cicd + Send + Sync + 'static {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_api_operation_display() {
+        assert_eq!(format!("{}", ApiOperation::MergeRequest), "merge_request");
+        assert_eq!(format!("{}", ApiOperation::Pipeline), "pipeline");
+        assert_eq!(format!("{}", ApiOperation::Project), "project");
+    }
+}

--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -52,8 +52,6 @@ impl Display for ApiOperation {
     }
 }
 
-pub trait Remote: RemoteProject + MergeRequest + Cicd + Send + Sync + 'static {}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/browse.rs
+++ b/src/browse.rs
@@ -19,17 +19,17 @@ pub fn execute(
             Ok(open::that(remote_url)?)
         }
         BrowseOptions::MergeRequests => {
-            let remote = remote::get(domain, path, config, false)?;
+            let remote = remote::get_project(domain, path, config, false)?;
             Ok(open::that(remote.get_url(BrowseOptions::MergeRequests))?)
         }
         BrowseOptions::MergeRequestId(id) => {
-            let remote = remote::get(domain, path, config, false)?;
+            let remote = remote::get_project(domain, path, config, false)?;
             Ok(open::that(
                 remote.get_url(BrowseOptions::MergeRequestId(id)),
             )?)
         }
         BrowseOptions::Pipelines => {
-            let remote = remote::get(domain, path, config, false)?;
+            let remote = remote::get_project(domain, path, config, false)?;
             Ok(open::that(remote.get_url(BrowseOptions::Pipelines))?)
         }
     }

--- a/src/cicd.rs
+++ b/src/cicd.rs
@@ -1,29 +1,114 @@
+use std::io::Write;
 use std::sync::Arc;
 
-use crate::cli::PipelineOptions;
-use crate::config::Config;
-use crate::remote;
+use crate::api_traits::Cicd;
+use crate::cli::{PipelineOperation, PipelineOptions};
 use crate::Result;
 
-pub fn execute(
+pub fn execute<W: Write>(
+    remote: Arc<dyn Cicd>,
     options: PipelineOptions,
-    config: Arc<Config>,
-    domain: String,
-    path: String,
+    writer: &mut W,
 ) -> Result<()> {
-    match options {
-        PipelineOptions::List { refresh_cache } => {
-            let remote = remote::get(domain, path, config, refresh_cache)?;
-            let pipelines = remote.list_pipelines()?;
-            if pipelines.is_empty() {
-                println!("No pipelines found.");
-                return Ok(());
+    match options.operation {
+        PipelineOperation::List => list_pipelines(remote, writer),
+    }
+}
+
+fn list_pipelines<W: Write>(remote: Arc<dyn Cicd>, mut writer: W) -> Result<()> {
+    let pipelines = remote.list_pipelines()?;
+    if pipelines.is_empty() {
+        writer.write_all(b"No pipelines found.\n")?;
+        return Ok(());
+    }
+    writer.write_all(b"URL | Branch | SHA | Created at | Status\n")?;
+    for pipeline in pipelines {
+        writer.write_all(format!("{}\n", pipeline).as_bytes())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use crate::cli::PipelineOptions;
+    use crate::error;
+    use crate::remote::Pipeline;
+
+    use super::*;
+
+    #[derive(Clone, Builder)]
+    struct PipelineList {
+        #[builder(default = "vec![]")]
+        pipelines: Vec<Pipeline>,
+        #[builder(default = "false")]
+        error: bool,
+    }
+
+    impl Cicd for PipelineList {
+        fn list_pipelines(&self) -> Result<Vec<Pipeline>> {
+            if self.error {
+                return Err(error::gen("Error"));
             }
-            println!("URL | Branch | SHA | Created at | Status");
-            for pipeline in pipelines {
-                println!("{}", pipeline);
-            }
-            Ok(())
+            let pp = self.pipelines.clone();
+            Ok(pp)
         }
+
+        fn get_pipeline(&self, _id: i64) -> Result<Pipeline> {
+            let pp = self.pipelines.clone();
+            Ok(pp[0].clone())
+        }
+    }
+
+    #[test]
+    fn test_list_pipelines() {
+        let pp_remote = PipelineListBuilder::default()
+            .pipelines(vec![
+                Pipeline::new(
+                    "success",
+                    "https://gitlab.com/owner/repo/-/pipelines/123",
+                    "master",
+                    "1234567890abcdef",
+                    "2020-01-01T00:00:00Z",
+                ),
+                Pipeline::new(
+                    "failed",
+                    "https://gitlab.com/owner/repo/-/pipelines/456",
+                    "master",
+                    "1234567890abcdef",
+                    "2020-01-01T00:00:00Z",
+                ),
+            ])
+            .build()
+            .unwrap();
+        let mut buf = Vec::new();
+        let pp_options = PipelineOptions {
+            operation: PipelineOperation::List,
+            refresh_cache: false,
+        };
+        execute(Arc::new(pp_remote), pp_options, &mut buf).unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "URL | Branch | SHA | Created at | Status\n\
+             https://gitlab.com/owner/repo/-/pipelines/123 | master | 1234567890abcdef | 2020-01-01T00:00:00Z | success\n\
+             https://gitlab.com/owner/repo/-/pipelines/456 | master | 1234567890abcdef | 2020-01-01T00:00:00Z | failed\n")
+    }
+
+    #[test]
+    fn test_list_pipelines_empty() {
+        let pp_remote = PipelineListBuilder::default().build().unwrap();
+        let mut buf = Vec::new();
+        list_pipelines(Arc::new(pp_remote), &mut buf).unwrap();
+        assert_eq!("No pipelines found.\n", String::from_utf8(buf).unwrap(),)
+    }
+
+    #[test]
+    fn test_list_pipelines_error() {
+        let pp_remote = PipelineListBuilder::default().error(true).build().unwrap();
+        let pp_options = PipelineOptions {
+            operation: PipelineOperation::List,
+            refresh_cache: false,
+        };
+        let mut buf = Vec::new();
+        assert!(execute(Arc::new(pp_remote), pp_options, &mut buf).is_err());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,9 @@ enum Command {
 struct ProjectCommand {
     #[clap(subcommand)]
     pub subcommand: ProjectSubcommand,
+    /// Refresh the cache
+    #[clap(long, short)]
+    pub refresh: bool,
 }
 
 #[derive(Parser)]
@@ -202,8 +205,14 @@ pub struct PipelineOptions {
 }
 
 #[derive(Debug)]
-pub enum ProjectOptions {
+pub enum ProjectOperation {
     Info { id: Option<i64> },
+}
+
+#[derive(Debug)]
+pub struct ProjectOptions {
+    pub operation: ProjectOperation,
+    pub refresh_cache: bool,
 }
 
 // From impls - private clap structs to public domain structs
@@ -302,7 +311,12 @@ impl From<PipelineCommand> for PipelineOptions {
 impl From<ProjectCommand> for ProjectOptions {
     fn from(options: ProjectCommand) -> Self {
         match options.subcommand {
-            ProjectSubcommand::Info(options) => ProjectOptions::Info { id: options.id },
+            ProjectSubcommand::Info(options_info) => ProjectOptions {
+                operation: ProjectOperation::Info {
+                    id: options_info.id,
+                },
+                refresh_cache: options.refresh,
+            },
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -192,8 +192,13 @@ pub enum BrowseOptions {
     Pipelines,
 }
 
-pub enum PipelineOptions {
-    List { refresh_cache: bool },
+pub enum PipelineOperation {
+    List,
+}
+
+pub struct PipelineOptions {
+    pub operation: PipelineOperation,
+    pub refresh_cache: bool,
 }
 
 #[derive(Debug)]
@@ -281,11 +286,13 @@ impl From<BrowseCommand> for BrowseOptions {
 impl From<PipelineCommand> for PipelineOptions {
     fn from(options: PipelineCommand) -> Self {
         match options.subcommand {
-            Some(PipelineSubcommand::List) => PipelineOptions::List {
+            Some(PipelineSubcommand::List) => PipelineOptions {
+                operation: PipelineOperation::List,
                 refresh_cache: options.refresh,
             },
             // defaults to list all pipelines
-            None => PipelineOptions::List {
+            None => PipelineOptions {
+                operation: PipelineOperation::List,
                 refresh_cache: options.refresh,
             },
         }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -158,11 +158,11 @@ pub fn show_summary_merge_request(
         true,
         Style::Bold,
     );
-    show_input("Target branch", args.target_branch(), false, Style::Bold);
-    show_input("Assignee", args.username(), false, Style::Bold);
-    show_input("Title", args.title(), false, Style::Bold);
-    if !args.description().is_empty() {
-        show_input("Description:", args.description(), true, Style::Bold);
+    show_input("Target branch", &args.target_branch, false, Style::Bold);
+    show_input("Assignee", &args.username, false, Style::Bold);
+    show_input("Title", &args.title, false, Style::Bold);
+    if !args.description.is_empty() {
+        show_input("Description:", &args.description, true, Style::Bold);
     } else {
         show_input("Description", "None", false, Style::Bold);
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -181,7 +181,7 @@ pub fn checkout(runner: &impl Runner<Response = Response>, branch: &str) -> Resu
 }
 
 /// Repo represents a local git repository
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Repo {
     current_branch: String,
     dirty: bool,

--- a/src/github.rs
+++ b/src/github.rs
@@ -3,7 +3,6 @@ use serde::Serialize;
 use crate::api_traits::ApiOperation;
 use crate::api_traits::Cicd;
 use crate::api_traits::MergeRequest;
-use crate::api_traits::Remote;
 use crate::api_traits::RemoteProject;
 use crate::cli::BrowseOptions;
 use crate::config::ConfigProperties;
@@ -411,8 +410,6 @@ impl<R: HttpRunner<Response = Response>> Cicd for Github<R> {
         todo!()
     }
 }
-
-impl<R: HttpRunner<Response = Response> + Send + Sync + 'static> Remote for Github<R> {}
 
 #[cfg(test)]
 mod test {

--- a/src/github.rs
+++ b/src/github.rs
@@ -193,10 +193,10 @@ impl<R: HttpRunner<Response = Response>> RemoteProject for Github<R> {
 impl<R: HttpRunner<Response = Response>> MergeRequest for Github<R> {
     fn open(&self, args: MergeRequestArgs) -> Result<MergeRequestResponse> {
         let mut body: HashMap<&str, String> = HashMap::new();
-        body.insert("head", args.source_branch().to_string());
-        body.insert("base", args.target_branch().to_string());
-        body.insert("title", args.title().to_string());
-        body.insert("body", args.description().to_string());
+        body.insert("head", args.source_branch.clone());
+        body.insert("base", args.target_branch);
+        body.insert("title", args.title);
+        body.insert("body", args.description);
         let mr_url = format!("{}/repos/{}/pulls", self.rest_api_basepath, self.path);
         let mut request = self.http_request(&mr_url, Some(body), POST, ApiOperation::MergeRequest);
         match self.runner.run(&mut request) {
@@ -244,7 +244,7 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Github<R> {
                         self.rest_api_basepath, self.path, id
                     );
                     let mut body: HashMap<&str, &Vec<&str>> = HashMap::new();
-                    let assignees = vec![args.username()];
+                    let assignees = vec![args.username.as_str()];
                     body.insert("assignees", &assignees);
                     self.runner.run(&mut self.http_request(
                         &issues_url,
@@ -263,7 +263,7 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Github<R> {
                 // There is an existing pull request already.
                 // Gather its URL by querying Github pull requests filtering by
                 // namespace:branch
-                let remote_pr_branch = format!("{}:{}", self.path, args.source_branch());
+                let remote_pr_branch = format!("{}:{}", self.path, args.source_branch);
                 let existing_mr_url = format!("{}?head={}", mr_url, remote_pr_branch);
                 let mut request: http::Request<()> =
                     self.http_request(&existing_mr_url, None, GET, ApiOperation::MergeRequest);
@@ -418,6 +418,7 @@ impl<R: HttpRunner<Response = Response> + Send + Sync + 'static> Remote for Gith
 mod test {
     use crate::{
         io::ResponseBuilder,
+        remote::MergeRequestArgsBuilder,
         test::utils::{config, get_contract, ContractType, MockRunner},
     };
 
@@ -456,7 +457,7 @@ mod test {
     #[test]
     fn test_open_merge_request() {
         let config = config();
-        let mr_args = MergeRequestArgs::new();
+        let mr_args = MergeRequestArgsBuilder::default().build().unwrap();
 
         let domain = "github.com".to_string();
         let path = "jordilin/githapi";
@@ -487,7 +488,7 @@ mod test {
     #[test]
     fn test_open_merge_request_error_status_code() {
         let config = config();
-        let mr_args = MergeRequestArgs::new();
+        let mr_args = MergeRequestArgsBuilder::default().build().unwrap();
 
         let domain = "github.com".to_string();
         let path = "jordilin/githapi";

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -54,15 +54,12 @@ impl<R> Gitlab<R> {
 impl<R: HttpRunner<Response = Response>> MergeRequest for Gitlab<R> {
     fn open(&self, args: MergeRequestArgs) -> Result<MergeRequestResponse> {
         let mut body = HashMap::new();
-        body.insert("source_branch", args.source_branch().to_string());
-        body.insert("target_branch", args.target_branch().to_string());
-        body.insert("title", args.title().to_string());
-        body.insert("assignee_id", args.assignee_id().to_string());
-        body.insert("description", args.description().to_string());
-        body.insert(
-            "remove_source_branch",
-            args.remove_source_branch().to_string(),
-        );
+        body.insert("source_branch", args.source_branch);
+        body.insert("target_branch", args.target_branch);
+        body.insert("title", args.title);
+        body.insert("assignee_id", args.assignee_id);
+        body.insert("description", args.description);
+        body.insert("remove_source_branch", args.remove_source_branch);
         let url = format!("{}/merge_requests", self.rest_api_basepath());
         let mut request = http::Request::new(&url, http::Method::POST)
             .with_api_operation(ApiOperation::MergeRequest)
@@ -342,6 +339,7 @@ impl<R: HttpRunner<Response = Response> + Send + Sync + 'static> Remote for Gitl
 
 #[cfg(test)]
 mod test {
+    use crate::remote::MergeRequestArgsBuilder;
     use crate::test::utils::{config, get_contract, ContractType, MockRunner};
 
     use crate::io::{CmdInfo, ResponseBuilder};
@@ -421,7 +419,7 @@ mod test {
     fn test_open_merge_request() {
         let config = config();
 
-        let mr_args = MergeRequestArgs::new();
+        let mr_args = MergeRequestArgsBuilder::default().build().unwrap();
 
         let domain = "gitlab.com".to_string();
         let path = "jordilin/gitlapi";
@@ -448,7 +446,7 @@ mod test {
     fn test_open_merge_request_error() {
         let config = config();
 
-        let mr_args = MergeRequestArgs::new();
+        let mr_args = MergeRequestArgsBuilder::default().build().unwrap();
         let domain = "gitlab.com".to_string();
         let path = "jordilin/gitlapi".to_string();
         let response = ResponseBuilder::default().status(400).build().unwrap();
@@ -461,7 +459,7 @@ mod test {
     fn test_merge_request_already_exists_status_code_409_conflict() {
         let config = config();
 
-        let mr_args = MergeRequestArgs::new();
+        let mr_args = MergeRequestArgsBuilder::default().build().unwrap();
 
         let domain = "gitlab.com".to_string();
         let path = "jordilin/gitlapi".to_string();

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -1,4 +1,4 @@
-use crate::api_traits::{ApiOperation, Cicd, MergeRequest, Remote, RemoteProject};
+use crate::api_traits::{ApiOperation, Cicd, MergeRequest, RemoteProject};
 use crate::cli::BrowseOptions;
 use crate::config::ConfigProperties;
 use crate::error::{self, AddContext};
@@ -333,9 +333,6 @@ impl<R: HttpRunner<Response = Response>> Cicd for Gitlab<R> {
         todo!();
     }
 }
-
-// impl Remote for Gitlab
-impl<R: HttpRunner<Response = Response> + Send + Sync + 'static> Remote for Gitlab<R> {}
 
 #[cfg(test)]
 mod test {

--- a/src/io.rs
+++ b/src/io.rs
@@ -23,7 +23,7 @@ pub trait HttpRunner {
     fn api_max_pages<T: Serialize>(&self, cmd: &Request<T>) -> u32;
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum CmdInfo {
     StatusModified(bool),
     RemoteUrl { domain: String, path: String },

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use gr::{
     cli::{parse_cli, CliOptions},
     error, git,
     io::CmdInfo,
-    merge_request, project, remote,
+    merge_request, project,
     shell::Shell,
     Result,
 };
@@ -29,13 +29,7 @@ fn main() -> Result<()> {
             let config = Arc::new(gr::config::Config::default());
             browse::execute(options, config, domain, path)
         }
-        CliOptions::Pipeline(options) => {
-            let remote = remote::get_cicd(domain, path, config, options.refresh_cache)?;
-            cicd::execute(remote, options, &mut std::io::stdout())
-        }
-        CliOptions::Project(options) => {
-            let remote = remote::get_project(domain, path, config, options.refresh_cache)?;
-            project::execute(remote, options, &mut std::io::stdout())
-        }
+        CliOptions::Pipeline(options) => cicd::execute(options, config, domain, path),
+        CliOptions::Project(options) => project::execute(options, config, domain, path),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,9 @@ fn main() -> Result<()> {
             let remote = remote::get_cicd(domain, path, config, options.refresh_cache)?;
             cicd::execute(remote, options, &mut std::io::stdout())
         }
-        CliOptions::Project(options) => project::execute(options, config, domain, path),
+        CliOptions::Project(options) => {
+            let remote = remote::get_project(domain, path, config, options.refresh_cache)?;
+            project::execute(remote, options, &mut std::io::stdout())
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use gr::{
     cli::{parse_cli, CliOptions},
     error, git,
     io::CmdInfo,
-    merge_request, project,
+    merge_request, project, remote,
     shell::Shell,
     Result,
 };
@@ -29,7 +29,10 @@ fn main() -> Result<()> {
             let config = Arc::new(gr::config::Config::default());
             browse::execute(options, config, domain, path)
         }
-        CliOptions::Pipeline(options) => cicd::execute(options, config, domain, path),
+        CliOptions::Pipeline(options) => {
+            let remote = remote::get_cicd(domain, path, config, options.refresh_cache)?;
+            cicd::execute(remote, options, &mut std::io::stdout())
+        }
         CliOptions::Project(options) => project::execute(options, config, domain, path),
     }
 }

--- a/src/merge_request.rs
+++ b/src/merge_request.rs
@@ -110,8 +110,8 @@ fn user_prompt_confirmation(
     };
 
     Ok(MergeRequestArgsBuilder::default()
-        .title(mr_body.repo.title().to_string())
-        .description(description)
+        .title(user_input.title)
+        .description(user_input.description)
         .source_branch(mr_body.repo.current_branch().to_string())
         .target_branch(target_branch.to_string())
         .assignee_id(user_input.user_id.to_string())

--- a/src/merge_request.rs
+++ b/src/merge_request.rs
@@ -116,6 +116,8 @@ fn user_prompt_confirmation(
         .target_branch(target_branch.to_string())
         .assignee_id(user_input.user_id.to_string())
         .username(user_input.username)
+        // TODO make this configurable
+        .remove_source_branch("true".to_string())
         .build()?)
 }
 

--- a/src/merge_request.rs
+++ b/src/merge_request.rs
@@ -1,12 +1,15 @@
 use std::sync::Arc;
 
-use crate::api_traits::Remote;
+use crate::api_traits::MergeRequest;
 
+use crate::api_traits::RemoteProject;
 use crate::config::ConfigProperties;
 use crate::error::GRError;
 use crate::exec;
+use crate::git::Repo;
 use crate::remote::Member;
 use crate::remote::MergeRequestArgs;
+use crate::remote::MergeRequestArgsBuilder;
 use crate::remote::MergeRequestState;
 use crate::remote::Project;
 use crate::shell::Shell;
@@ -37,12 +40,14 @@ pub fn execute(
             refresh_cache,
             open_browser,
         } => {
-            let remote = remote::get(domain, path, config.clone(), refresh_cache)?;
+            let mr_remote =
+                remote::get_mr(domain.clone(), path.clone(), config.clone(), refresh_cache)?;
+            let project_remote = remote::get_project(domain, path, config.clone(), refresh_cache)?;
+            let mr_body = get_repo_project_info(cmds(project_remote, title, description))?;
             open(
-                remote,
+                mr_remote,
                 config,
-                title,
-                description,
+                mr_body,
                 target_branch,
                 noprompt,
                 open_browser,
@@ -52,41 +57,184 @@ pub fn execute(
             state,
             refresh_cache,
         } => {
-            let remote = remote::get(domain, path, config, refresh_cache)?;
+            let remote = remote::get_mr(domain, path, config, refresh_cache)?;
             list(remote, state)
         }
         MergeRequestOptions::Merge { id } => {
-            let remote = remote::get(domain, path, config, false)?;
+            let remote = remote::get_mr(domain, path, config, false)?;
             merge(remote, id)
         }
         MergeRequestOptions::Checkout { id } => {
-            let remote = remote::get(domain, path, config, false)?;
+            let remote = remote::get_mr(domain, path, config, false)?;
             checkout(remote, id)
         }
         MergeRequestOptions::Close { id } => {
-            let remote = remote::get(domain, path, config, false)?;
+            let remote = remote::get_mr(domain, path, config, false)?;
             close(remote, id)
         }
     }
 }
 
+fn user_prompt_confirmation(
+    mr_body: &MergeRequestBody,
+    config: Arc<impl ConfigProperties>,
+    description: String,
+    target_branch: &String,
+    noprompt: bool,
+) -> Result<MergeRequestArgs> {
+    let user_input = if noprompt {
+        let preferred_assignee_members = mr_body
+            .members
+            .iter()
+            .filter(|member| member.username == config.preferred_assignee_username().to_string())
+            .collect::<Vec<&Member>>();
+        if preferred_assignee_members.len() != 1 {
+            return Err(GRError::PreconditionNotMet(
+                "Cannot get preferred assignee user id".to_string(),
+            )
+            .into());
+        }
+        dialog::MergeRequestUserInput::new(
+            &mr_body.repo.title(),
+            &description,
+            preferred_assignee_members[0].id,
+            &preferred_assignee_members[0].username,
+        )
+    } else {
+        dialog::prompt_user_merge_request_info(
+            &mr_body.repo.title(),
+            &description,
+            &mr_body.members,
+            config,
+        )?
+    };
+
+    Ok(MergeRequestArgsBuilder::default()
+        .title(mr_body.repo.title().to_string())
+        .description(description)
+        .source_branch(mr_body.repo.current_branch().to_string())
+        .target_branch(target_branch.to_string())
+        .assignee_id(user_input.user_id.to_string())
+        .username(user_input.username)
+        .build()?)
+}
+
 /// Open a merge request.
 fn open(
-    remote: Arc<dyn Remote>,
+    remote: Arc<dyn MergeRequest>,
     config: Arc<impl ConfigProperties>,
-    title: Option<String>,
-    description: Option<String>,
+    mr_body: MergeRequestBody,
     target_branch: Option<String>,
     noprompt: bool,
     open_browser: bool,
 ) -> Result<()> {
-    // data gathering stage. Gather local repo and remote project data.
+    let source_branch = &mr_body.repo.current_branch();
+    let target_branch = &target_branch.unwrap_or(mr_body.project.default_branch().to_string());
 
-    let data = cmds(remote.clone());
+    let description = build_description(
+        &mr_body.repo.last_commit_message(),
+        config.merge_request_description_signature(),
+    );
+
+    // make sure we are in a feature branch or bail
+    in_feature_branch(source_branch, target_branch)?;
+
+    // confirm title, description and assignee
+    let args = user_prompt_confirmation(&mr_body, config, description, target_branch, noprompt)?;
+
+    git::rebase(&Shell, "origin", target_branch)?;
+
+    let outgoing_commits = git::outgoing_commits(&Shell, "origin", target_branch)?;
+
+    if outgoing_commits.is_empty() {
+        return Err(GRError::PreconditionNotMet(
+            "No outgoing commits found. Please commit your changes.".to_string(),
+        )
+        .into());
+    }
+
+    // show summary of merge request and confirm
+    if let Ok(()) = dialog::show_summary_merge_request(&outgoing_commits, &args) {
+        println!("\nTaking off... 🚀\n");
+        git::push(&Shell, "origin", &mr_body.repo)?;
+        let merge_request_response = remote.open(args)?;
+        println!("Merge request opened: {}", merge_request_response.web_url);
+        if open_browser {
+            open::that(merge_request_response.web_url)?;
+        }
+    }
+    Ok(())
+}
+
+/// Required commands to build a Project and a Repository
+///
+/// The order of the commands being declared is not important as they will be
+/// executed in parallel.
+fn cmds(
+    remote: Arc<dyn RemoteProject + Send + Sync + 'static>,
+    title: Option<String>,
+    description: Option<String>,
+) -> Vec<Cmd<CmdInfo>> {
+    let remote_cl = remote.clone();
+    let remote_project_cmd = move || -> Result<CmdInfo> { remote_cl.get_project_data(None) };
+    let remote_members_cmd = move || -> Result<CmdInfo> { remote.get_project_members() };
+    let git_status_cmd = || -> Result<CmdInfo> { git::status(&Shell) };
+    let git_fetch_cmd = || -> Result<CmdInfo> { git::fetch(&Shell) };
+    let title = title.unwrap_or("".to_string());
+    let git_title_cmd = move || -> Result<CmdInfo> {
+        if title.is_empty() {
+            git::last_commit(&Shell)
+        } else {
+            Ok(CmdInfo::LastCommitSummary(title.clone()))
+        }
+    };
+    let git_current_branch = || -> Result<CmdInfo> { git::current_branch(&Shell) };
+    let description = description.unwrap_or("".to_string());
+    let git_last_commit_message = move || -> Result<CmdInfo> {
+        if description.is_empty() {
+            git::last_commit_message(&Shell)
+        } else {
+            Ok(CmdInfo::LastCommitMessage(description.clone()))
+        }
+    };
+    let cmds: Vec<Cmd<CmdInfo>> = vec![
+        Box::new(remote_project_cmd),
+        Box::new(remote_members_cmd),
+        Box::new(git_status_cmd),
+        Box::new(git_fetch_cmd),
+        Box::new(git_title_cmd),
+        Box::new(git_current_branch),
+        Box::new(git_last_commit_message),
+    ];
+    cmds
+}
+
+// append description signature from the configuration
+fn build_description(description: &str, signature: &str) -> String {
+    if description.is_empty() && signature.is_empty() {
+        return "".to_string();
+    }
+    if description.is_empty() {
+        return signature.to_string();
+    }
+    if signature.is_empty() {
+        return description.to_string();
+    }
+    format!("{}\n\n{}", description, signature)
+}
+
+#[derive(Builder)]
+struct MergeRequestBody {
+    repo: Repo,
+    project: Project,
+    members: Vec<Member>,
+}
+
+fn get_repo_project_info(cmds: Vec<Cmd<CmdInfo>>) -> Result<MergeRequestBody> {
     let mut project = Project::default();
     let mut members = Vec::new();
     let mut repo = git::Repo::default();
-    let cmd_results = exec::parallel_stream(data);
+    let cmd_results = exec::parallel_stream(cmds);
     for cmd_result in cmd_results {
         match cmd_result {
             Ok(CmdInfo::Project(project_data)) => {
@@ -104,108 +252,11 @@ fn open(
             _ => {}
         }
     }
-    let source_branch = &repo.current_branch();
-    let target_branch = &target_branch.unwrap_or(project.default_branch().to_string());
-    let title = title.unwrap_or(repo.title().to_string());
-    let description = description.unwrap_or(repo.last_commit_message().to_string());
-    let preferred_assignee_username = config.preferred_assignee_username().to_string();
-
-    // append description signature from the configuration
-    let description =
-        if description.is_empty() && config.merge_request_description_signature().is_empty() {
-            description
-        } else if description.is_empty() {
-            config.merge_request_description_signature().to_string()
-        } else if config.merge_request_description_signature().is_empty() {
-            description
-        } else {
-            format!(
-                "{}\n\n{}",
-                description,
-                config.merge_request_description_signature()
-            )
-        };
-
-    // make sure we are in a feature branch or bail
-    in_feature_branch(source_branch, target_branch)?;
-
-    // confirm title, description and assignee
-    let user_input = if noprompt {
-        let preferred_assignee_members = members
-            .iter()
-            .filter(|member| member.username == preferred_assignee_username)
-            .collect::<Vec<&Member>>();
-        if preferred_assignee_members.len() != 1 {
-            return Err(GRError::PreconditionNotMet(
-                "Cannot get preferred assignee user id".to_string(),
-            )
-            .into());
-        }
-        dialog::MergeRequestUserInput::new(
-            &title,
-            &description,
-            preferred_assignee_members[0].id,
-            &preferred_assignee_members[0].username,
-        )
-    } else {
-        dialog::prompt_user_merge_request_info(&title, &description, &members, config)?
-    };
-
-    git::rebase(&Shell, "origin", target_branch)?;
-
-    let outgoing_commits = git::outgoing_commits(&Shell, "origin", target_branch)?;
-
-    if outgoing_commits.is_empty() {
-        return Err(GRError::PreconditionNotMet(
-            "No outgoing commits found. Please commit your changes.".to_string(),
-        )
-        .into());
-    }
-
-    let args = MergeRequestArgs::new()
-        .with_title(&user_input.title)
-        .with_description(&user_input.description)
-        .with_source_branch(source_branch)
-        .with_target_branch(target_branch)
-        .with_assignee_id(&user_input.user_id.to_string())
-        .with_username(&user_input.username);
-
-    // show summary of merge request and confirm
-    if let Ok(()) = dialog::show_summary_merge_request(&outgoing_commits, &args) {
-        println!("\nTaking off... 🚀\n");
-        git::push(&Shell, "origin", &repo)?;
-        let merge_request_response = remote.open(args)?;
-        println!("Merge request opened: {}", merge_request_response.web_url);
-        if open_browser {
-            open::that(merge_request_response.web_url)?;
-        }
-    }
-    Ok(())
-}
-
-/// Required commands to build a Project and a Repository
-///
-/// The order of the commands being declared is not important as they will be
-/// executed in parallel.
-fn cmds(remote: Arc<dyn Remote>) -> Vec<Cmd<CmdInfo>> {
-    let remote_cl = remote.clone();
-    let remote_project_cmd = move || -> Result<CmdInfo> { remote_cl.get_project_data(None) };
-    let remote_members_cmd = move || -> Result<CmdInfo> { remote.get_project_members() };
-    let git_status_cmd = || -> Result<CmdInfo> { git::status(&Shell) };
-    let git_fetch_cmd = || -> Result<CmdInfo> { git::fetch(&Shell) };
-    let git_title_cmd = || -> Result<CmdInfo> { git::last_commit(&Shell) };
-    let git_current_branch = || -> Result<CmdInfo> { git::current_branch(&Shell) };
-    let git_last_commit_message = || -> Result<CmdInfo> { git::last_commit_message(&Shell) };
-    let cmds: Vec<Cmd<CmdInfo>> = vec![
-        Box::new(remote_project_cmd),
-        Box::new(remote_members_cmd),
-        Box::new(git_status_cmd),
-        Box::new(git_fetch_cmd),
-        Box::new(git_title_cmd),
-        Box::new(git_current_branch),
-        Box::new(git_last_commit_message),
-    ];
-    cmds
+    Ok(MergeRequestBodyBuilder::default()
+        .repo(repo)
+        .project(project)
+        .members(members)
+        .build()?)
 }
 
 /// This makes sure we don't push to branches considered to be upstream in most cases.
@@ -233,7 +284,7 @@ fn in_feature_branch(current_branch: &str, upstream_branch: &str) -> Result<()> 
     }
 }
 
-fn list(remote: Arc<dyn Remote>, state: MergeRequestState) -> Result<()> {
+fn list(remote: Arc<dyn MergeRequest>, state: MergeRequestState) -> Result<()> {
     let merge_requests = remote.list(state)?;
     if merge_requests.is_empty() {
         println!("No merge requests found.");
@@ -249,19 +300,19 @@ fn list(remote: Arc<dyn Remote>, state: MergeRequestState) -> Result<()> {
     Ok(())
 }
 
-fn merge(remote: Arc<dyn Remote>, merge_request_id: i64) -> Result<()> {
+fn merge(remote: Arc<dyn MergeRequest>, merge_request_id: i64) -> Result<()> {
     let merge_request = remote.merge(merge_request_id)?;
     println!("Merge request merged: {}", merge_request.web_url);
     Ok(())
 }
 
-fn checkout(remote: Arc<dyn Remote>, id: i64) -> Result<()> {
+fn checkout(remote: Arc<dyn MergeRequest>, id: i64) -> Result<()> {
     let merge_request = remote.get(id)?;
     git::fetch(&Shell)?;
     git::checkout(&Shell, &merge_request.source_branch)
 }
 
-fn close(remote: Arc<dyn Remote>, id: i64) -> Result<()> {
+fn close(remote: Arc<dyn MergeRequest>, id: i64) -> Result<()> {
     let merge_request = remote.close(id)?;
     println!("Merge request closed: {}", merge_request.web_url);
     Ok(())
@@ -269,6 +320,8 @@ fn close(remote: Arc<dyn Remote>, id: i64) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use crate::error;
+
     use super::*;
 
     #[test]
@@ -298,6 +351,112 @@ mod tests {
         for (current_branch, upstream_branch) in test_cases {
             let result = in_feature_branch(current_branch, upstream_branch);
             assert!(result.is_err());
+        }
+    }
+
+    fn get_cmds_mock(cmd: Arc<CmdMock>) -> Vec<Cmd<CmdInfo>> {
+        let cmd_status = cmd.clone();
+        let git_status_cmd =
+            move || -> Result<CmdInfo> { Ok(CmdInfo::StatusModified(cmd_status.status_modified)) };
+        let title_cmd = cmd.clone();
+        let git_title_cmd = move || -> Result<CmdInfo> {
+            Ok(CmdInfo::LastCommitSummary(
+                title_cmd.last_commit_summary.clone(),
+            ))
+        };
+        let message_cmd = cmd.clone();
+        let git_message_cmd = move || -> Result<CmdInfo> {
+            Ok(CmdInfo::LastCommitMessage(
+                message_cmd.last_commit_message.clone(),
+            ))
+        };
+        let branch_cmd = cmd.clone();
+        let git_current_branch =
+            move || -> Result<CmdInfo> { Ok(CmdInfo::Branch(branch_cmd.current_branch.clone())) };
+        let project_cmd = cmd.clone();
+        let remote_project_cmd =
+            move || -> Result<CmdInfo> { Ok(CmdInfo::Project(project_cmd.project.clone())) };
+        let members_cmd = cmd.clone();
+        let remote_members_cmd =
+            move || -> Result<CmdInfo> { Ok(CmdInfo::Members(members_cmd.members.clone())) };
+        let mut cmds: Vec<Cmd<CmdInfo>> = vec![
+            Box::new(remote_project_cmd),
+            Box::new(remote_members_cmd),
+            Box::new(git_status_cmd),
+            Box::new(git_title_cmd),
+            Box::new(git_message_cmd),
+            Box::new(git_current_branch),
+        ];
+        if cmd.error {
+            let error_cmd =
+                move || -> Result<CmdInfo> { Err(error::gen("Failure retrieving data")) };
+            cmds.push(Box::new(error_cmd));
+        }
+        cmds
+    }
+
+    #[derive(Clone, Builder)]
+    struct CmdMock {
+        #[builder(default = "false")]
+        status_modified: bool,
+        last_commit_summary: String,
+        current_branch: String,
+        last_commit_message: String,
+        members: Vec<Member>,
+        project: Project,
+        #[builder(default = "false")]
+        error: bool,
+    }
+
+    #[test]
+    fn test_get_repo_project_info() {
+        let cmd_mock = CmdMockBuilder::default()
+            .status_modified(true)
+            .current_branch("current-branch".to_string())
+            .last_commit_summary("title".to_string())
+            .last_commit_message("last-commit-message".to_string())
+            .members(Vec::new())
+            .project(Project::default())
+            .build()
+            .unwrap();
+        let cmds = get_cmds_mock(Arc::new(cmd_mock));
+        let result = get_repo_project_info(cmds);
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result.repo.title(), "title");
+        assert_eq!(result.repo.current_branch(), "current-branch");
+        assert_eq!(result.repo.last_commit_message(), "last-commit-message");
+        assert_eq!(result.members.len(), 0);
+    }
+
+    #[test]
+    fn test_get_repo_project_info_cmds_error() {
+        let cmd_mock = CmdMockBuilder::default()
+            .status_modified(true)
+            .current_branch("current-branch".to_string())
+            .last_commit_summary("title".to_string())
+            .last_commit_message("last-commit-message".to_string())
+            .members(Vec::new())
+            .project(Project::default())
+            .error(true)
+            .build()
+            .unwrap();
+        let cmds = get_cmds_mock(Arc::new(cmd_mock));
+        let result = get_repo_project_info(cmds);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_description_signature() {
+        let description_signature_table = [
+            ("", "", ""),
+            ("", "signature", "signature"),
+            ("description", "", "description"),
+            ("description", "signature", "description\n\nsignature"),
+        ];
+        for (description, signature, expected) in description_signature_table {
+            let result = build_description(description, signature);
+            assert_eq!(result, expected);
         }
     }
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,25 +1,116 @@
+use crate::api_traits::RemoteProject;
+use crate::cli::ProjectOperation;
 use crate::cli::ProjectOptions;
-use crate::config::Config;
 use crate::error;
 use crate::io::CmdInfo;
-use crate::remote;
 use crate::Result;
+use std::io::Write;
 use std::sync::Arc;
 
-pub fn execute(
+pub fn execute<W: Write>(
+    remote: Arc<dyn RemoteProject>,
     options: ProjectOptions,
-    config: Arc<Config>,
-    domain: String,
-    path: String,
+    writer: &mut W,
 ) -> Result<()> {
-    let remote = remote::get(domain, path, config, false)?;
-    match options {
-        ProjectOptions::Info { id } => {
+    match options.operation {
+        ProjectOperation::Info { id } => {
             let CmdInfo::Project(project_data) = remote.get_project_data(id)? else {
-                return Err(error::gen("No project data found."));
+                return Err(error::GRError::ApplicationError(
+                    "remote.get_project_data expects CmdInfo::Project invariant".to_string(),
+                )
+                .into());
             };
-            println!("{}", project_data);
+            writer.write_all(format!("{}\n", project_data).as_bytes())?;
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    use crate::remote::Project;
+
+    #[derive(Builder)]
+    struct ProjectDataProvider {
+        #[builder(default = "false")]
+        error: bool,
+        cmd_info: CmdInfo,
+    }
+
+    impl RemoteProject for ProjectDataProvider {
+        fn get_project_data(&self, _id: Option<i64>) -> crate::Result<CmdInfo> {
+            if self.error {
+                return Err(error::gen("Error"));
+            }
+            match self.cmd_info {
+                CmdInfo::Project(_) => Ok(self.cmd_info.clone()),
+                _ => Ok(CmdInfo::Ignore),
+            }
+        }
+
+        fn get_project_members(&self) -> crate::Result<CmdInfo> {
+            todo!()
+        }
+
+        fn get_url(&self, _option: crate::cli::BrowseOptions) -> String {
+            todo!()
+        }
+    }
+
+    #[test]
+    fn test_project_data_gets_persisted() {
+        let remote = ProjectDataProviderBuilder::default()
+            .cmd_info(CmdInfo::Project(Project::default()))
+            .build()
+            .unwrap();
+        let remote = Arc::new(remote);
+        let mut writer = Vec::new();
+        let options = ProjectOptions {
+            operation: ProjectOperation::Info { id: None },
+            refresh_cache: false,
+        };
+        execute(remote, options, &mut writer).unwrap();
+        assert!(writer.len() > 0);
+    }
+
+    #[test]
+    fn test_project_data_error() {
+        let remote = ProjectDataProviderBuilder::default()
+            .cmd_info(CmdInfo::Project(Project::default()))
+            .error(true)
+            .build()
+            .unwrap();
+        let remote = Arc::new(remote);
+        let mut writer = Vec::new();
+        let options = ProjectOptions {
+            operation: ProjectOperation::Info { id: None },
+            refresh_cache: false,
+        };
+        execute(remote, options, &mut writer).unwrap_err();
+        assert!(writer.len() == 0);
+    }
+
+    #[test]
+    fn test_get_project_data_wrong_cmdinfo_invariant() {
+        let remote = ProjectDataProviderBuilder::default()
+            .cmd_info(CmdInfo::Ignore)
+            .build()
+            .unwrap();
+        let remote = Arc::new(remote);
+        let mut writer = Vec::new();
+        let options = ProjectOptions {
+            operation: ProjectOperation::Info { id: None },
+            refresh_cache: false,
+        };
+        let result = execute(remote, options, &mut writer);
+        match result {
+            Ok(_) => panic!("Expected error"),
+            Err(err) => match err.downcast_ref::<error::GRError>() {
+                Some(error::GRError::ApplicationError(_)) => (),
+                _ => panic!("Expected error::GRError::ApplicationError"),
+            },
+        }
+    }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 
-use crate::api_traits::Remote;
+use crate::api_traits::{Cicd, Remote};
 use crate::cache::filesystem::FileCache;
 use crate::config::Config;
 use crate::github::Github;
@@ -215,7 +215,7 @@ impl MergeRequestArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone,Debug)]
 pub struct Pipeline {
     status: String,
     web_url: String,
@@ -275,6 +275,7 @@ macro_rules! get {
 }
 
 get!(get, Remote);
+get!(get_cicd, Cicd);
 
 #[cfg(test)]
 mod test {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -124,96 +124,20 @@ impl Display for MergeRequestState {
 
 #[derive(Builder)]
 pub struct MergeRequestArgs {
-    title: String,
-    description: String,
-    source_branch: String,
-    target_branch: String,
-    assignee_id: String,
-    username: String,
-    remove_source_branch: String,
-}
-
-impl Default for MergeRequestArgs {
-    fn default() -> Self {
-        MergeRequestArgs {
-            title: String::new(),
-            description: String::new(),
-            source_branch: String::new(),
-            target_branch: String::new(),
-            assignee_id: String::new(),
-            username: String::new(),
-            remove_source_branch: "true".to_string(),
-        }
-    }
-}
-
-impl MergeRequestArgs {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn with_title(mut self, title: &str) -> Self {
-        self.title = title.to_string();
-        self
-    }
-
-    pub fn with_description(mut self, description: &str) -> Self {
-        self.description = description.to_string();
-        self
-    }
-
-    pub fn with_source_branch(mut self, source_branch: &str) -> Self {
-        self.source_branch = source_branch.to_string();
-        self
-    }
-
-    pub fn with_target_branch(mut self, target_branch: &str) -> Self {
-        self.target_branch = target_branch.to_string();
-        self
-    }
-
-    pub fn with_assignee_id(mut self, assignee_id: &str) -> Self {
-        self.assignee_id = assignee_id.to_string();
-        self
-    }
-
-    pub fn with_username(mut self, username: &str) -> Self {
-        self.username = username.to_string();
-        self
-    }
-
-    pub fn with_remove_source_branch(mut self, remove_source_branch: bool) -> Self {
-        self.remove_source_branch = remove_source_branch.to_string();
-        self
-    }
-
-    pub fn title(&self) -> &str {
-        &self.title
-    }
-
-    pub fn description(&self) -> &str {
-        &self.description
-    }
-
-    pub fn source_branch(&self) -> &str {
-        &self.source_branch
-    }
-
-    pub fn target_branch(&self) -> &str {
-        &self.target_branch
-    }
-
-    pub fn assignee_id(&self) -> &str {
-        &self.assignee_id
-    }
-
-    pub fn username(&self) -> &str {
-        &self.username
-    }
-
-    pub fn remove_source_branch(&self) -> &str {
-        &self.remove_source_branch
-    }
+    #[builder(default)]
+    pub title: String,
+    #[builder(default)]
+    pub description: String,
+    #[builder(default)]
+    pub source_branch: String,
+    #[builder(default)]
+    pub target_branch: String,
+    #[builder(default)]
+    pub assignee_id: String,
+    #[builder(default)]
+    pub username: String,
+    #[builder(default = "String::from(\"true\")")]
+    pub remove_source_branch: String,
 }
 
 #[derive(Clone, Debug)]
@@ -286,10 +210,12 @@ mod test {
 
     #[test]
     fn test_merge_request_args_with_custom_title() {
-        let args = MergeRequestArgs::new()
-            .with_source_branch("source")
-            .with_target_branch("target")
-            .with_title("title");
+        let args = MergeRequestArgsBuilder::default()
+            .source_branch("source".to_string())
+            .target_branch("target".to_string())
+            .title("title".to_string())
+            .build()
+            .unwrap();
 
         assert_eq!(args.source_branch, "source");
         assert_eq!(args.target_branch, "target");
@@ -300,14 +226,16 @@ mod test {
 
     #[test]
     fn test_merge_request_get_all_fields() {
-        let args = MergeRequestArgs::new()
-            .with_source_branch("source")
-            .with_target_branch("target")
-            .with_title("title")
-            .with_description("description")
-            .with_assignee_id("assignee_id")
-            .with_username("username")
-            .with_remove_source_branch(false);
+        let args = MergeRequestArgsBuilder::default()
+            .source_branch("source".to_string())
+            .target_branch("target".to_string())
+            .title("title".to_string())
+            .description("description".to_string())
+            .assignee_id("assignee_id".to_string())
+            .username("username".to_string())
+            .remove_source_branch("false".to_string())
+            .build()
+            .unwrap();
 
         assert_eq!(args.source_branch, "source");
         assert_eq!(args.target_branch, "target");

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 
-use crate::api_traits::{Cicd, Remote};
+use crate::api_traits::{Cicd, Remote, RemoteProject};
 use crate::cache::filesystem::FileCache;
 use crate::config::Config;
 use crate::github::Github;
@@ -10,7 +10,7 @@ use crate::{error, http};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Project {
     id: i64,
     default_branch: String,
@@ -49,7 +49,7 @@ impl Display for Project {
     }
 }
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct Member {
     pub id: i64,
     pub name: String,
@@ -66,7 +66,7 @@ impl Member {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MergeRequestResponse {
     pub id: i64,
     pub web_url: String,
@@ -215,7 +215,7 @@ impl MergeRequestArgs {
     }
 }
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub struct Pipeline {
     status: String,
     web_url: String,
@@ -276,6 +276,7 @@ macro_rules! get {
 
 get!(get, Remote);
 get!(get_cicd, Cicd);
+get!(get_project, RemoteProject);
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Make use of specific remote trait instead of the `Remote` trait.
Remove the `Remote` trait.
Interface segregation will allow for easier testing.