### PR TITLE
Refactor pipeline status handling in Github implementation

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -153,7 +153,7 @@ impl MergeRequestListBodyArgs {
 
 #[derive(Builder, Clone, Debug)]
 pub struct Pipeline {
-    status: String,
+    pub status: String,
     web_url: String,
     branch: String,
     sha: String,


### PR DESCRIPTION
I noticed that when a run is happening its
conclusion might not be available. Use status or
just "unknown" if action run state is not
available
