### PR TITLE
Filter by creation date and sort asc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +414,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +494,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
@@ -838,6 +873,7 @@ name = "gr"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "console",
  "derive_builder",
@@ -973,6 +1009,29 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1117,6 +1176,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1846,6 +1914,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "1.0.56"
 anyhow = "1.0.79"
 flate2 = "1.0.28"
 derive_builder = "0.13.0"
+chrono = "0.4.34"
 
 [dev-dependencies]
 # disable basic-cookies from httpmock - not needed

--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -35,6 +35,10 @@ pub trait Cicd {
     fn num_pages(&self) -> Result<Option<u32>>;
 }
 
+pub trait Timestamp {
+    fn created_at(&self) -> String;
+}
+
 /// Types of API resources attached to a request. The request will carry this
 /// information so we can decide if we need to use the cache or not based on
 /// global configuration.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -199,6 +199,9 @@ struct ListArgs {
     /// List the given page number
     #[clap(long)]
     page: Option<i64>,
+    /// Created after date (ISO 8601 YYYY-MM-DDTHH:MM:SSZ)
+    #[clap(long)]
+    created_after: Option<String>,
 }
 
 #[derive(Parser)]
@@ -295,6 +298,7 @@ impl From<ListMergeRequest> for MergeRequestOptions {
             .num_pages(options.list_args.num_pages)
             .refresh_cache(options.list_args.refresh)
             .no_headers(options.list_args.no_headers)
+            .created_after(options.list_args.created_after)
             .build()
             .unwrap();
         MergeRequestOptions::List(MergeRequestListCliArgs::new(
@@ -373,6 +377,7 @@ impl From<ListArgs> for PipelineOptions {
                 .num_pages(options.num_pages)
                 .refresh_cache(options.refresh)
                 .no_headers(options.no_headers)
+                .created_after(options.created_after)
                 .build()
                 .unwrap(),
         )

--- a/src/github/merge_request.rs
+++ b/src/github/merge_request.rs
@@ -211,6 +211,7 @@ pub struct GithubMergeRequestFields {
     source_branch: String,
     author: String,
     updated_at: String,
+    created_at: String,
 }
 
 impl From<&serde_json::Value> for GithubMergeRequestFields {
@@ -230,6 +231,10 @@ impl From<&serde_json::Value> for GithubMergeRequestFields {
                 .as_str()
                 .unwrap_or_default()
                 .to_string(),
+            created_at: merge_request_data["created_at"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
         }
     }
 }
@@ -242,6 +247,7 @@ impl From<GithubMergeRequestFields> for MergeRequestResponse {
             .source_branch(fields.source_branch)
             .author(fields.author)
             .updated_at(fields.updated_at)
+            .created_at(fields.created_at)
             .build()
             .unwrap()
     }

--- a/src/github/project.rs
+++ b/src/github/project.rs
@@ -65,6 +65,7 @@ pub struct GithubProjectFields {
     id: i64,
     default_branch: String,
     html_url: String,
+    created_at: String,
 }
 
 impl From<&serde_json::Value> for GithubProjectFields {
@@ -79,13 +80,19 @@ impl From<&serde_json::Value> for GithubProjectFields {
                 .to_string()
                 .trim_matches('"')
                 .to_string(),
+            created_at: project_data["created_at"]
+                .to_string()
+                .trim_matches('"')
+                .to_string(),
         }
     }
 }
 
 impl From<GithubProjectFields> for Project {
     fn from(fields: GithubProjectFields) -> Self {
-        Project::new(fields.id, &fields.default_branch).with_html_url(&fields.html_url)
+        Project::new(fields.id, &fields.default_branch)
+            .with_html_url(&fields.html_url)
+            .with_created_at(&fields.created_at)
     }
 }
 
@@ -93,6 +100,7 @@ pub struct GithubMemberFields {
     id: i64,
     login: String,
     name: String,
+    created_at: String,
 }
 
 impl From<&serde_json::Value> for GithubMemberFields {
@@ -101,6 +109,9 @@ impl From<&serde_json::Value> for GithubMemberFields {
             id: member_data["id"].as_i64().unwrap(),
             login: member_data["login"].as_str().unwrap().to_string(),
             name: "".to_string(),
+            // Github does not provide created_at field in the response for
+            // Members (aka contributors). Set it to UNIX epoch.
+            created_at: "1970-01-01T00:00:00Z".to_string(),
         }
     }
 }
@@ -111,6 +122,7 @@ impl From<GithubMemberFields> for Member {
             .id(fields.id)
             .username(fields.login)
             .name(fields.name)
+            .created_at(fields.created_at)
             .build()
             .unwrap()
     }

--- a/src/gitlab/merge_request.rs
+++ b/src/gitlab/merge_request.rs
@@ -146,6 +146,7 @@ pub struct GitlabMergeRequestFields {
     source_branch: String,
     author: String,
     updated_at: String,
+    created_at: String,
 }
 
 impl From<&serde_json::Value> for GitlabMergeRequestFields {
@@ -156,6 +157,7 @@ impl From<&serde_json::Value> for GitlabMergeRequestFields {
             source_branch: data["source_branch"].as_str().unwrap().to_string(),
             author: data["author"]["username"].as_str().unwrap().to_string(),
             updated_at: data["updated_at"].as_str().unwrap().to_string(),
+            created_at: data["created_at"].as_str().unwrap().to_string(),
         }
     }
 }
@@ -168,6 +170,7 @@ impl From<GitlabMergeRequestFields> for MergeRequestResponse {
             .source_branch(fields.source_branch)
             .author(fields.author)
             .updated_at(fields.updated_at)
+            .created_at(fields.created_at)
             .build()
             .unwrap()
     }

--- a/src/gitlab/project.rs
+++ b/src/gitlab/project.rs
@@ -75,6 +75,7 @@ pub struct GitlabMemberFields {
     id: i64,
     name: String,
     username: String,
+    created_at: String,
 }
 
 impl From<&serde_json::Value> for GitlabMemberFields {
@@ -83,6 +84,7 @@ impl From<&serde_json::Value> for GitlabMemberFields {
             id: data["id"].as_i64().unwrap(),
             name: data["name"].as_str().unwrap().to_string(),
             username: data["username"].as_str().unwrap().to_string(),
+            created_at: data["created_at"].as_str().unwrap().to_string(),
         }
     }
 }
@@ -93,6 +95,7 @@ impl From<GitlabMemberFields> for Member {
             .id(fields.id)
             .name(fields.name.to_string())
             .username(fields.username.to_string())
+            .created_at(fields.created_at.to_string())
             .build()
             .unwrap()
     }

--- a/src/gitlab/project.rs
+++ b/src/gitlab/project.rs
@@ -53,6 +53,7 @@ pub struct GitlabProjectFields {
     id: i64,
     default_branch: String,
     web_url: String,
+    created_at: String,
 }
 
 impl From<&serde_json::Value> for GitlabProjectFields {
@@ -61,13 +62,16 @@ impl From<&serde_json::Value> for GitlabProjectFields {
             id: data["id"].as_i64().unwrap(),
             default_branch: data["default_branch"].as_str().unwrap().to_string(),
             web_url: data["web_url"].as_str().unwrap().to_string(),
+            created_at: data["created_at"].as_str().unwrap().to_string(),
         }
     }
 }
 
 impl From<GitlabProjectFields> for Project {
     fn from(fields: GitlabProjectFields) -> Self {
-        Project::new(fields.id, &fields.default_branch).with_html_url(&fields.web_url)
+        Project::new(fields.id, &fields.default_branch)
+            .with_html_url(&fields.web_url)
+            .with_created_at(&fields.created_at)
     }
 }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 
-use crate::api_traits::{Cicd, MergeRequest, RemoteProject};
+use crate::api_traits::{Cicd, MergeRequest, RemoteProject, Timestamp};
 use crate::cache::filesystem::FileCache;
 use crate::config::Config;
 use crate::error::GRError;
@@ -19,6 +19,7 @@ pub struct Project {
     default_branch: String,
     members: Vec<Member>,
     html_url: String,
+    created_at: String,
 }
 
 impl Project {
@@ -28,6 +29,7 @@ impl Project {
             default_branch: default_branch.to_string(),
             members: Vec::new(),
             html_url: String::new(),
+            created_at: String::new(),
         }
     }
 
@@ -52,16 +54,29 @@ impl Display for Project {
     }
 }
 
+impl Timestamp for Project {
+    fn created_at(&self) -> String {
+        self.created_at.clone()
+    }
+}
+
 #[derive(Builder, Clone, Debug, PartialEq, Default)]
 pub struct Member {
     pub id: i64,
     pub name: String,
     pub username: String,
+    pub created_at: String,
 }
 
 impl Member {
     pub fn builder() -> MemberBuilder {
         MemberBuilder::default()
+    }
+}
+
+impl Timestamp for Member {
+    fn created_at(&self) -> String {
+        self.created_at.clone()
     }
 }
 
@@ -77,11 +92,19 @@ pub struct MergeRequestResponse {
     pub updated_at: String,
     #[builder(default)]
     pub source_branch: String,
+    #[builder(default)]
+    pub created_at: String,
 }
 
 impl MergeRequestResponse {
     pub fn builder() -> MergeRequestResponseBuilder {
         MergeRequestResponseBuilder::default()
+    }
+}
+
+impl Timestamp for MergeRequestResponse {
+    fn created_at(&self) -> String {
+        self.created_at.clone()
     }
 }
 
@@ -168,6 +191,12 @@ impl Pipeline {
     }
 }
 
+impl Timestamp for Pipeline {
+    fn created_at(&self) -> String {
+        self.created_at.clone()
+    }
+}
+
 /// List cli args can be used across multiple APIs that support pagination.
 #[derive(Builder)]
 pub struct ListRemoteCliArgs {
@@ -200,8 +229,12 @@ impl ListRemoteCliArgs {
 /// clients when executing HTTP requests.
 #[derive(Builder, Clone)]
 pub struct ListBodyArgs {
-    pub page: i64,
-    pub max_pages: i64,
+    #[builder(setter(strip_option), default)]
+    pub page: Option<i64>,
+    #[builder(setter(strip_option), default)]
+    pub max_pages: Option<i64>,
+    #[builder(default)]
+    pub created_after: Option<String>,
 }
 
 impl ListBodyArgs {
@@ -220,7 +253,7 @@ pub fn validate_from_to_page(remote_cli_args: &ListRemoteCliArgs) -> Result<Opti
                 .unwrap(),
         ));
     }
-    return match (remote_cli_args.from_page, remote_cli_args.to_page) {
+    let body_args = match (remote_cli_args.from_page, remote_cli_args.to_page) {
         (Some(from_page), Some(to_page)) => {
             if from_page < 0 || to_page < 0 {
                 return Err(GRError::PreconditionNotMet(
@@ -236,13 +269,13 @@ pub fn validate_from_to_page(remote_cli_args: &ListRemoteCliArgs) -> Result<Opti
             }
 
             let max_pages = to_page - from_page + 1;
-            Ok(Some(
+            Some(
                 ListBodyArgs::builder()
                     .page(from_page)
                     .max_pages(max_pages)
                     .build()
                     .unwrap(),
-            ))
+            )
         }
         (Some(_), None) => {
             return Err(
@@ -256,16 +289,35 @@ pub fn validate_from_to_page(remote_cli_args: &ListRemoteCliArgs) -> Result<Opti
                 )
                 .into());
             }
-            Ok(Some(
+            Some(
                 ListBodyArgs::builder()
                     .page(1)
                     .max_pages(to_page)
                     .build()
                     .unwrap(),
-            ))
+            )
         }
-        (None, None) => Ok(None),
+        (None, None) => None,
     };
+    if let Some(created_after) = &remote_cli_args.created_after {
+        if let Some(body_args) = &body_args {
+            return Ok(Some(
+                ListBodyArgs::builder()
+                    .page(body_args.page.unwrap())
+                    .max_pages(body_args.max_pages.unwrap())
+                    .created_after(Some(created_after.to_string()))
+                    .build()
+                    .unwrap(),
+            ));
+        }
+        return Ok(Some(
+            ListBodyArgs::builder()
+                .created_after(Some(created_after.to_string()))
+                .build()
+                .unwrap(),
+        ));
+    }
+    Ok(body_args)
 }
 
 #[derive(Builder, Clone)]
@@ -374,8 +426,8 @@ mod test {
             .build()
             .unwrap();
         let args = validate_from_to_page(&args).unwrap().unwrap();
-        assert_eq!(args.page, 1);
-        assert_eq!(args.max_pages, 3);
+        assert_eq!(args.page, Some(1));
+        assert_eq!(args.max_pages, Some(3));
     }
 
     #[test]
@@ -481,7 +533,35 @@ mod test {
             .build()
             .unwrap();
         let args = validate_from_to_page(&args).unwrap().unwrap();
-        assert_eq!(args.page, 5);
-        assert_eq!(args.max_pages, 1);
+        assert_eq!(args.page, Some(5));
+        assert_eq!(args.max_pages, Some(1));
+    }
+
+    #[test]
+    fn test_include_created_after_in_list_body_args() {
+        let created_after = "2021-01-01T00:00:00Z";
+        let args = ListRemoteCliArgs::builder()
+            .created_after(Some(created_after.to_string()))
+            .build()
+            .unwrap();
+        let args = validate_from_to_page(&args).unwrap().unwrap();
+        assert_eq!(args.created_after.unwrap(), created_after);
+    }
+
+    #[test]
+    fn test_includes_from_to_page_and_created_after_in_list_body_args() {
+        let from_page = Some(1);
+        let to_page = Some(3);
+        let created_after = "2021-01-01T00:00:00Z";
+        let args = ListRemoteCliArgs::builder()
+            .from_page(from_page)
+            .to_page(to_page)
+            .created_after(Some(created_after.to_string()))
+            .build()
+            .unwrap();
+        let args = validate_from_to_page(&args).unwrap().unwrap();
+        assert_eq!(args.page, Some(1));
+        assert_eq!(args.max_pages, Some(3));
+        assert_eq!(args.created_after.unwrap(), created_after);
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -38,6 +38,12 @@ impl Project {
         self
     }
 
+    // TODO - builder pattern
+    pub fn with_created_at(mut self, created_at: &str) -> Self {
+        self.created_at = created_at.to_string();
+        self
+    }
+
     pub fn default_branch(&self) -> &str {
         &self.default_branch
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -65,6 +65,7 @@ pub struct Member {
     pub id: i64,
     pub name: String,
     pub username: String,
+    #[builder(default)]
     pub created_at: String,
 }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -183,6 +183,8 @@ pub struct ListRemoteCliArgs {
     pub no_headers: bool,
     #[builder(default)]
     pub page_number: Option<i64>,
+    #[builder(default)]
+    pub created_after: Option<String>,
 }
 
 impl ListRemoteCliArgs {

--- a/src/remote/query.rs
+++ b/src/remote/query.rs
@@ -16,6 +16,7 @@ use crate::{
     io::{HttpRunner, Response},
     json_load_page, json_loads,
     remote::ListBodyArgs,
+    time::filter_by_date,
     Result,
 };
 
@@ -133,7 +134,7 @@ macro_rules! paged {
             iter_over_sub_array: Option<&str>,
             operation: ApiOperation,
         ) -> Result<Vec<$return_type>> {
-            let request = build_list_request(url, list_args, request_headers, operation);
+            let request = build_list_request(url, &list_args, request_headers, operation);
             let paginator = Paginator::new(&runner, request, url);
             let all_data = paginator
                 .map(|response| {
@@ -171,7 +172,14 @@ macro_rules! paged {
                 .collect::<Result<Vec<Vec<$return_type>>>>()
                 .map(|paged_data| paged_data.into_iter().flatten().collect());
             match all_data {
-                Ok(paged_data) => Ok(paged_data),
+                Ok(paged_data) => {
+                    if list_args.is_some() {
+                        let created_after = list_args.unwrap().created_after;
+                        Ok(filter_by_date(paged_data, created_after)?)
+                    } else {
+                        Ok(paged_data)
+                    }
+                }
                 Err(err) => Err(err),
             }
         }
@@ -180,22 +188,23 @@ macro_rules! paged {
 
 fn build_list_request(
     url: &str,
-    list_args: Option<ListBodyArgs>,
+    list_args: &Option<ListBodyArgs>,
     request_headers: Headers,
     operation: ApiOperation,
 ) -> Request<()> {
     let mut request: http::Request<()> =
         http::Request::new(url, http::Method::GET).with_api_operation(operation);
     request.set_headers(request_headers);
-    if list_args.is_some() {
-        let from_page = list_args.as_ref().unwrap().page;
-        let url = if url.contains('?') {
-            format!("{}&page={}", url, &from_page)
-        } else {
-            format!("{}?page={}", url, &from_page)
-        };
-        request.set_max_pages(list_args.unwrap().max_pages);
-        request.set_url(&url);
+    if let Some(list_args) = list_args {
+        if let Some(from_page) = list_args.page {
+            let url = if url.contains('?') {
+                format!("{}&page={}", url, &from_page)
+            } else {
+                format!("{}?page={}", url, &from_page)
+            };
+            request.set_max_pages(list_args.max_pages.unwrap());
+            request.set_url(&url);
+        }
     }
     request
 }

--- a/src/remote/query.rs
+++ b/src/remote/query.rs
@@ -16,7 +16,7 @@ use crate::{
     io::{HttpRunner, Response},
     json_load_page, json_loads,
     remote::ListBodyArgs,
-    time::filter_by_date,
+    time::sort_filter_by_date,
     Result,
 };
 
@@ -172,14 +172,7 @@ macro_rules! paged {
                 .collect::<Result<Vec<Vec<$return_type>>>>()
                 .map(|paged_data| paged_data.into_iter().flatten().collect());
             match all_data {
-                Ok(paged_data) => {
-                    if list_args.is_some() {
-                        let created_after = list_args.unwrap().created_after;
-                        Ok(filter_by_date(paged_data, created_after)?)
-                    } else {
-                        Ok(paged_data)
-                    }
-                }
+                Ok(paged_data) => Ok(sort_filter_by_date(paged_data, list_args)?),
                 Err(err) => Err(err),
             }
         }

--- a/src/time.rs
+++ b/src/time.rs
@@ -259,6 +259,7 @@ mod tests {
             TimestampMock::new("2021-02-02T00:00:00Z"),
         ];
         let filtered = sort_filter_by_date(data, Some(list_args)).unwrap();
+        assert_eq!(2, filtered.len());
         assert_eq!("2021-02-02T00:00:00Z", filtered[0].created_at());
         assert_eq!("2021-03-02T00:00:00Z", filtered[1].created_at());
     }
@@ -272,6 +273,7 @@ mod tests {
         ];
         // no filter, just data sort ascending.
         let sorted = sort_filter_by_date(data, None).unwrap();
+        assert_eq!(3, sorted.len());
         assert_eq!("2020-12-31T00:00:00Z", sorted[0].created_at());
         assert_eq!("2021-01-01T00:00:00Z", sorted[1].created_at());
         assert_eq!("2021-01-02T00:00:00Z", sorted[2].created_at());


### PR DESCRIPTION
Filters merge requests and pipelines by creation date.

Provide a cli option --created-after <date> to filter data created after that
specific date.

Sort data listed by creation date in ascending order by default, so newest
information comes at the very bottom of the shell, so no need to scroll up.
Some of the remote APIs might not support data ordering. Hence, the sort
operation is post-API call, so we have full control.

Github Members (collaborators) JSON payloads do not have a `created_at` field,
so it is set to the UNIX epoch string representation by default.