### PR TITLE
Move all print ops to display module

### DIFF
--- a/src/cicd.rs
+++ b/src/cicd.rs
@@ -2,7 +2,7 @@ use crate::api_traits::Cicd;
 use crate::cli::PipelineOptions;
 use crate::config::Config;
 use crate::remote::{ListRemoteCliArgs, PipelineBodyArgs};
-use crate::{remote, Result};
+use crate::{display, remote, Result};
 use std::io::Write;
 use std::sync::Arc;
 
@@ -52,12 +52,12 @@ fn list_pipelines<W: Write>(
         writer.write_all(b"No pipelines found.\n")?;
         return Ok(());
     }
-    if !cli_args.no_headers {
-        writer.write_all(b"URL | Branch | SHA | Created at | Status\n")?;
-    }
-    for pipeline in pipelines {
-        writer.write_all(format!("{}\n", pipeline).as_bytes())?;
-    }
+    display::print(
+        &mut writer,
+        pipelines,
+        cli_args.no_headers,
+        &cli_args.format,
+    )?;
     Ok(())
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -264,7 +264,7 @@ struct ListArgs {
     created_before: Option<String>,
     #[clap(long, default_value_t=SortModeCli::Asc)]
     sort: SortModeCli,
-    /// Output format
+    /// Output format. pipe " | " or csv ","
     #[clap(long, default_value_t=FormatCli::PIPE)]
     format: FormatCli,
 }
@@ -278,8 +278,8 @@ enum FormatCli {
 impl Display for FormatCli {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            FormatCli::CSV => write!(f, ","),
-            FormatCli::PIPE => write!(f, " | "),
+            FormatCli::CSV => write!(f, "csv"),
+            FormatCli::PIPE => write!(f, "pipe"),
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use crate::{
+    display::Format,
     docker::{DockerImageCliArgs, DockerListCliArgs},
     merge_request::{MergeRequestCliArgs, MergeRequestListCliArgs},
     remote::{ListRemoteCliArgs, ListSortMode, MergeRequestState},
@@ -263,6 +264,24 @@ struct ListArgs {
     created_before: Option<String>,
     #[clap(long, default_value_t=SortModeCli::Asc)]
     sort: SortModeCli,
+    /// Output format
+    #[clap(long, default_value_t=FormatCli::PIPE)]
+    format: FormatCli,
+}
+
+#[derive(ValueEnum, Clone, Debug)]
+enum FormatCli {
+    CSV,
+    PIPE,
+}
+
+impl Display for FormatCli {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            FormatCli::CSV => write!(f, ","),
+            FormatCli::PIPE => write!(f, " | "),
+        }
+    }
 }
 
 #[derive(ValueEnum, Clone, Debug)]
@@ -402,6 +421,7 @@ fn gen_list_args(list_args: ListArgs) -> ListRemoteCliArgs {
         .created_after(list_args.created_after)
         .created_before(list_args.created_before)
         .sort(list_args.sort.into())
+        .format(list_args.format.into())
         .build()
         .unwrap();
     list_args
@@ -423,6 +443,15 @@ impl From<CreateMergeRequest> for MergeRequestOptions {
                 .build()
                 .unwrap(),
         )
+    }
+}
+
+impl From<FormatCli> for Format {
+    fn from(format: FormatCli) -> Self {
+        match format {
+            FormatCli::CSV => Format::CSV,
+            FormatCli::PIPE => Format::PIPE,
+        }
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -112,6 +112,9 @@ struct ProjectInfo {
     /// ID of the project
     #[clap(long)]
     pub id: Option<i64>,
+    /// Output format. pipe " | " or csv ","
+    #[clap(long, default_value_t=FormatCli::PIPE)]
+    format: FormatCli,
 }
 
 #[derive(Parser)]
@@ -356,6 +359,7 @@ pub enum ProjectOperation {
 pub struct ProjectOptions {
     pub operation: ProjectOperation,
     pub refresh_cache: bool,
+    pub format: Format,
 }
 
 pub enum MergeRequestOptions {
@@ -551,6 +555,7 @@ impl From<ProjectCommand> for ProjectOptions {
                     id: options_info.id,
                 },
                 refresh_cache: options.refresh,
+                format: options_info.format.into(),
             },
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,7 +67,7 @@ struct DockerImageMetadata {
     #[clap(long)]
     pub no_headers: bool,
     /// Output format. pipe " | " or csv ","
-    #[clap(long, default_value_t=FormatCli::PIPE)]
+    #[clap(long, default_value_t=FormatCli::Pipe)]
     format: FormatCli,
 }
 
@@ -113,7 +113,7 @@ struct ProjectInfo {
     #[clap(long)]
     pub id: Option<i64>,
     /// Output format. pipe " | " or csv ","
-    #[clap(long, default_value_t=FormatCli::PIPE)]
+    #[clap(long, default_value_t=FormatCli::Pipe)]
     format: FormatCli,
 }
 
@@ -271,21 +271,21 @@ struct ListArgs {
     #[clap(long, default_value_t=SortModeCli::Asc)]
     sort: SortModeCli,
     /// Output format. pipe " | " or csv ","
-    #[clap(long, default_value_t=FormatCli::PIPE)]
+    #[clap(long, default_value_t=FormatCli::Pipe)]
     format: FormatCli,
 }
 
 #[derive(ValueEnum, Clone, Debug)]
 enum FormatCli {
-    CSV,
-    PIPE,
+    Csv,
+    Pipe,
 }
 
 impl Display for FormatCli {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            FormatCli::CSV => write!(f, "csv"),
-            FormatCli::PIPE => write!(f, "pipe"),
+            FormatCli::Csv => write!(f, "csv"),
+            FormatCli::Pipe => write!(f, "pipe"),
         }
     }
 }
@@ -457,8 +457,8 @@ impl From<CreateMergeRequest> for MergeRequestOptions {
 impl From<FormatCli> for Format {
     fn from(format: FormatCli) -> Self {
         match format {
-            FormatCli::CSV => Format::CSV,
-            FormatCli::PIPE => Format::PIPE,
+            FormatCli::Csv => Format::CSV,
+            FormatCli::Pipe => Format::PIPE,
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,6 +66,9 @@ struct DockerImageMetadata {
     /// Do not print headers
     #[clap(long)]
     pub no_headers: bool,
+    /// Output format. pipe " | " or csv ","
+    #[clap(long, default_value_t=FormatCli::PIPE)]
+    format: FormatCli,
 }
 
 #[derive(Parser)]
@@ -389,6 +392,7 @@ impl From<DockerImageMetadata> for DockerOptions {
                 .tag(options.tag)
                 .refresh_cache(options.refresh)
                 .no_headers(options.no_headers)
+                .format(options.format.into())
                 .build()
                 .unwrap(),
         )

--- a/src/display.rs
+++ b/src/display.rs
@@ -3,8 +3,8 @@ use std::{fmt::Display, io::Write};
 
 #[derive(Clone, Default)]
 pub enum Format {
-    #[default]
     CSV,
+    #[default]
     PIPE,
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,0 +1,83 @@
+use crate::Result;
+use std::{fmt::Display, io::Write};
+
+pub enum Format {
+    CSV,
+    PIPE,
+}
+
+impl Display for Format {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Format::CSV => write!(f, ","),
+            Format::PIPE => write!(f, " | "),
+        }
+    }
+}
+
+impl From<&Format> for &str {
+    fn from(f: &Format) -> Self {
+        match f {
+            Format::CSV => ",",
+            Format::PIPE => " | ",
+        }
+    }
+}
+
+pub struct DisplayBody {
+    pub columns: Vec<Column>,
+}
+
+impl DisplayBody {
+    pub fn new(columns: Vec<Column>) -> Self {
+        Self { columns }
+    }
+}
+
+pub struct Column {
+    pub name: String,
+    pub value: String,
+}
+
+impl Column {
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: value.into(),
+        }
+    }
+}
+
+pub fn print<W: Write, D: Into<DisplayBody> + Clone>(
+    w: &mut W,
+    data: Vec<D>,
+    no_headers: bool,
+    format: &Format,
+) -> Result<()> {
+    if data.is_empty() {
+        return Ok(());
+    }
+    if !no_headers {
+        // Get the headers from the first row of columns
+        let headers = data[0]
+            .clone()
+            .into()
+            .columns
+            .iter()
+            .map(|c| c.name.clone())
+            .collect::<Vec<_>>();
+        writeln!(w, "{}", headers.join(format.into()))?;
+    }
+    for d in data {
+        let d = d.into();
+        let num_columns = d.columns.len();
+        for i in 0..num_columns {
+            write!(w, "{}", d.columns[i].value)?;
+            if i < num_columns - 1 {
+                write!(w, "{}", format)?;
+            }
+        }
+        writeln!(w)?;
+    }
+    Ok(())
+}

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use std::{fmt::Display, io::Write};
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub enum Format {
     CSV,
     #[default]

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,9 @@
 use crate::Result;
 use std::{fmt::Display, io::Write};
 
+#[derive(Clone, Default)]
 pub enum Format {
+    #[default]
     CSV,
     PIPE,
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,8 +1,4 @@
-use std::{
-    fmt::{self, Display, Formatter},
-    io::Write,
-    sync::Arc,
-};
+use std::{io::Write, sync::Arc};
 
 use crate::{
     api_traits::{ContainerRegistry, Timestamp},
@@ -47,7 +43,7 @@ impl DockerListBodyArgs {
     }
 }
 
-#[derive(Builder)]
+#[derive(Builder, Clone)]
 pub struct RegistryRepository {
     pub id: i64,
     pub location: String,
@@ -61,13 +57,14 @@ impl RegistryRepository {
     }
 }
 
-impl Display for RegistryRepository {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{} | {} | {} | {}",
-            self.id, self.location, self.tags_count, self.created_at
-        )
+impl From<RegistryRepository> for DisplayBody {
+    fn from(repo: RegistryRepository) -> DisplayBody {
+        DisplayBody::new(vec![
+            Column::new("ID", repo.id.to_string()),
+            Column::new("Location", repo.location),
+            Column::new("Tags count", repo.tags_count.to_string()),
+            Column::new("Created at", repo.created_at),
+        ])
     }
 }
 
@@ -77,7 +74,7 @@ impl Timestamp for RegistryRepository {
     }
 }
 
-#[derive(Builder)]
+#[derive(Builder, Clone)]
 pub struct RepositoryTag {
     pub name: String,
     pub path: String,
@@ -97,9 +94,13 @@ impl Timestamp for RepositoryTag {
     }
 }
 
-impl Display for RepositoryTag {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{} | {} | {}", self.name, self.path, self.location)
+impl From<RepositoryTag> for DisplayBody {
+    fn from(tag: RepositoryTag) -> DisplayBody {
+        DisplayBody::new(vec![
+            Column::new("Name", tag.name),
+            Column::new("Path", tag.path),
+            Column::new("Location", tag.location),
+        ])
     }
 }
 
@@ -195,19 +196,22 @@ fn validate_and_list<W: Write>(
         .body_args(body_args)
         .build()?;
     if body_args.tags {
-        if cli_args.list_args.no_headers {
-            return list_repository_tags(remote, body_args, writer);
-        }
-        let headers = "Name | Path | Location\n";
-        writer.write_all(headers.as_bytes())?;
-        return list_repository_tags(remote, body_args, writer);
+        let tags = remote.list_repository_tags(body_args)?;
+        display::print(
+            &mut writer,
+            tags,
+            cli_args.list_args.no_headers,
+            &cli_args.list_args.format,
+        )?;
+        return Ok(());
     }
-    if cli_args.list_args.no_headers {
-        return list_repositories(remote, body_args, writer);
-    }
-    let headers = "ID | Location | Tags count | Created at\n";
-    writer.write_all(headers.as_bytes())?;
-    list_repositories(remote, body_args, writer)
+    let repos = remote.list_repositories(body_args)?;
+    display::print(
+        &mut writer,
+        repos,
+        cli_args.list_args.no_headers,
+        &cli_args.list_args.format,
+    )
 }
 
 fn get_num_pages<W: Write>(
@@ -232,28 +236,6 @@ fn report_num_pages<W: Write>(pages: Result<Option<u32>>, mut writer: W) -> Resu
         Err(e) => {
             return Err(e);
         }
-    }
-    Ok(())
-}
-
-pub fn list_repository_tags<W: Write>(
-    remote: Arc<dyn ContainerRegistry>,
-    args: DockerListBodyArgs,
-    mut writer: W,
-) -> Result<()> {
-    for tag in remote.list_repository_tags(args)? {
-        writer.write_all(format!("{}\n", tag).as_bytes())?;
-    }
-    Ok(())
-}
-
-pub fn list_repositories<W: Write>(
-    remote: Arc<dyn ContainerRegistry>,
-    args: DockerListBodyArgs,
-    mut writer: W,
-) -> Result<()> {
-    for repo in remote.list_repositories(args)? {
-        writer.write_all(format!("{}\n", repo).as_bytes())?;
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod time;
 pub type Result<T> = anyhow::Result<T>;
 pub type Error = anyhow::Error;
 pub type Cmd<T> = Box<dyn Fn() -> Result<T> + Send + Sync>;
+pub mod display;
 pub mod docker;
 
 #[macro_use]

--- a/src/merge_request.rs
+++ b/src/merge_request.rs
@@ -349,7 +349,7 @@ fn list<W: Write>(
         &mut writer,
         merge_requests,
         cli_args.list_args.no_headers,
-        &crate::display::Format::PIPE,
+        &cli_args.list_args.format,
     )?;
     Ok(())
 }

--- a/src/merge_request.rs
+++ b/src/merge_request.rs
@@ -345,18 +345,12 @@ fn list<W: Write>(
         writer.write_all(b"No merge requests found.\n")?;
         return Ok(());
     }
-    if !cli_args.list_args.no_headers {
-        writer.write_all(b"ID | Title | Author | URL | Updated at\n")?;
-    }
-    for mr in merge_requests {
-        writer.write_all(
-            format!(
-                "{} | {} | {} | {} | {}\n",
-                mr.id, mr.title, mr.author, mr.web_url, mr.updated_at
-            )
-            .as_bytes(),
-        )?;
-    }
+    crate::display::print(
+        &mut writer,
+        merge_requests,
+        cli_args.list_args.no_headers,
+        &crate::display::Format::PIPE,
+    )?;
     Ok(())
 }
 

--- a/src/merge_request.rs
+++ b/src/merge_request.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::api_traits::MergeRequest;
 use crate::api_traits::RemoteProject;
 use crate::config::ConfigProperties;
+use crate::display;
 use crate::error::GRError;
 use crate::exec;
 use crate::git::Repo;
@@ -345,7 +346,7 @@ fn list<W: Write>(
         writer.write_all(b"No merge requests found.\n")?;
         return Ok(());
     }
-    crate::display::print(
+    display::print(
         &mut writer,
         merge_requests,
         cli_args.list_args.no_headers,

--- a/src/project.rs
+++ b/src/project.rs
@@ -37,7 +37,7 @@ fn project_info<W: Write>(
         )
         .into());
     };
-    display::print(&mut writer, vec![project_data], false, &format)?;
+    display::print(&mut writer, vec![project_data], false, format)?;
     Ok(())
 }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display, Formatter};
 use crate::api_traits::{Cicd, ContainerRegistry, MergeRequest, RemoteProject, Timestamp};
 use crate::cache::filesystem::FileCache;
 use crate::config::Config;
-use crate::display::{Column, DisplayBody};
+use crate::display::{Column, DisplayBody, Format};
 use crate::error::GRError;
 use crate::github::Github;
 use crate::gitlab::Gitlab;
@@ -242,6 +242,8 @@ pub struct ListRemoteCliArgs {
     pub created_before: Option<String>,
     #[builder(default)]
     pub sort: ListSortMode,
+    #[builder(default)]
+    pub format: Format,
 }
 
 impl ListRemoteCliArgs {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -221,6 +221,20 @@ impl Timestamp for Pipeline {
     }
 }
 
+impl From<Pipeline> for DisplayBody {
+    fn from(p: Pipeline) -> DisplayBody {
+        DisplayBody {
+            columns: vec![
+                Column::new("URL", p.web_url),
+                Column::new("Branch", p.branch),
+                Column::new("SHA", p.sha),
+                Column::new("Created at", p.created_at),
+                Column::new("Status", p.status),
+            ],
+        }
+    }
+}
+
 /// List cli args can be used across multiple APIs that support pagination.
 #[derive(Builder, Clone)]
 pub struct ListRemoteCliArgs {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -50,14 +50,15 @@ impl Project {
     }
 }
 
-impl Display for Project {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        writeln!(f, "ID | Default Branch | URL")?;
-        write!(
-            f,
-            "{} | {} | {} ",
-            self.id, self.default_branch, self.html_url
-        )
+impl From<Project> for DisplayBody {
+    fn from(p: Project) -> DisplayBody {
+        DisplayBody {
+            columns: vec![
+                Column::new("ID", p.id.to_string()),
+                Column::new("Default Branch", p.default_branch),
+                Column::new("URL", p.html_url),
+            ],
+        }
     }
 }
 
@@ -454,16 +455,6 @@ pub struct PipelineBodyArgs {
 impl PipelineBodyArgs {
     pub fn builder() -> PipelineBodyArgsBuilder {
         PipelineBodyArgsBuilder::default()
-    }
-}
-
-impl Display for Pipeline {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} | {} | {} | {} | {}",
-            self.web_url, self.branch, self.sha, self.created_at, self.status
-        )
     }
 }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Display, Formatter};
 use crate::api_traits::{Cicd, ContainerRegistry, MergeRequest, RemoteProject, Timestamp};
 use crate::cache::filesystem::FileCache;
 use crate::config::Config;
+use crate::display::{Column, DisplayBody};
 use crate::error::GRError;
 use crate::github::Github;
 use crate::gitlab::Gitlab;
@@ -108,6 +109,20 @@ pub struct MergeRequestResponse {
 impl MergeRequestResponse {
     pub fn builder() -> MergeRequestResponseBuilder {
         MergeRequestResponseBuilder::default()
+    }
+}
+
+impl From<MergeRequestResponse> for DisplayBody {
+    fn from(mr: MergeRequestResponse) -> DisplayBody {
+        DisplayBody {
+            columns: vec![
+                Column::new("ID", mr.id.to_string()),
+                Column::new("Title", mr.title),
+                Column::new("Author", mr.author),
+                Column::new("URL", mr.web_url),
+                Column::new("Updated at", mr.updated_at),
+            ],
+        }
     }
 }
 


### PR DESCRIPTION
Also provide a --format arg to list operations. Defaults to what it used to be,
i.e "|" aka pipe and adding the option to format output using csv, .i.e ","