### PR TITLE
Change Release id to string

### DIFF
--- a/src/cmds/release.rs
+++ b/src/cmds/release.rs
@@ -21,7 +21,7 @@ impl ReleaseBodyArgs {
 
 #[derive(Builder, Clone)]
 pub struct Release {
-    id: i64,
+    id: String,
     url: String,
     tag: String,
     title: String,
@@ -43,7 +43,7 @@ impl From<Release> for DisplayBody {
             Column::new("Title", release.title),
             Column::new("Description", release.description),
             Column::new("URL", release.url),
-            Column::new("ID", release.id.to_string()),
+            Column::new("ID", release.id),
             Column::new("Created At", release.created_at),
             Column::new("Updated At", release.updated_at),
         ])
@@ -112,7 +112,7 @@ mod test {
                 return Ok(vec![]);
             }
             Ok(vec![Release {
-                id: 1,
+                id: String::from("1"),
                 url: String::from("https://github.com/jordilin/githapi/releases/tag/v0.1.20"),
                 tag: String::from("v1.0.0"),
                 title: String::from("First release"),

--- a/src/github/release.rs
+++ b/src/github/release.rs
@@ -32,7 +32,7 @@ impl<R: HttpRunner<Response = Response>> Deploy for Github<R> {
 }
 
 pub struct GithubReleaseFields {
-    id: i64,
+    id: String,
     url: String,
     tag: String,
     title: String,
@@ -44,7 +44,7 @@ pub struct GithubReleaseFields {
 impl From<&serde_json::Value> for GithubReleaseFields {
     fn from(value: &serde_json::Value) -> Self {
         Self {
-            id: value["id"].as_i64().unwrap(),
+            id: value["id"].as_i64().unwrap().to_string(),
             url: value["html_url"].as_str().unwrap().to_string(),
             tag: value["tag_name"].as_str().unwrap().to_string(),
             title: value["name"].as_str().unwrap().to_string(),

--- a/src/gitlab/release.rs
+++ b/src/gitlab/release.rs
@@ -29,7 +29,7 @@ impl<R: HttpRunner<Response = Response>> Deploy for Gitlab<R> {
 }
 
 pub struct GitlabReleaseFields {
-    id: i64,
+    id: String,
     url: String,
     tag: String,
     title: String,
@@ -43,11 +43,7 @@ impl From<&serde_json::Value> for GitlabReleaseFields {
         Self {
             // There's no id available in the response per se. Grab the short commit
             // id instead
-            id: value["commit"]["short_id"]
-                .as_str()
-                .unwrap()
-                .parse()
-                .unwrap(),
+            id: value["commit"]["short_id"].as_str().unwrap().to_string(),
             url: value["_links"]["self"].as_str().unwrap().to_string(),
             tag: value["tag_name"].as_str().unwrap().to_string(),
             title: value["name"].as_str().unwrap().to_string(),


### PR DESCRIPTION
Gitlab has no Release ID in responses. So, we
gather the short SHA associated with the release.
This involves alphanumeric characters and not just
numeric ones.