### PR TITLE
Check ETag on cache refresh

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -336,7 +336,7 @@ impl<C: Cache<Resource>, D: ConfigProperties> HttpRunner for Client<C, D> {
                         Err(err) => return Err(err),
                     }
                 }
-                // check Etag is available in the default response.
+                // check ETag is available in the default response.
                 // If so, then we need to set the If-None-Match header.
                 if let Some(etag) = default_response.get_etag() {
                     cmd.set_header("If-None-Match", etag);

--- a/src/http.rs
+++ b/src/http.rs
@@ -326,15 +326,18 @@ impl<C: Cache<Resource>, D: ConfigProperties> HttpRunner for Client<C, D> {
         match cmd.method {
             Method::GET => {
                 let mut default_response = Response::builder().build()?;
-                if !self.refresh_cache {
-                    match self.cache.get(&cmd.resource) {
-                        Ok(CacheState::Fresh(response)) => return Ok(response),
-                        Ok(CacheState::Stale(response)) => {
-                            default_response = response;
+                match self.cache.get(&cmd.resource) {
+                    Ok(CacheState::Fresh(response)) => {
+                        if !self.refresh_cache {
+                            return Ok(response);
                         }
-                        Ok(CacheState::None) => {}
-                        Err(err) => return Err(err),
+                        default_response = response;
                     }
+                    Ok(CacheState::Stale(response)) => {
+                        default_response = response;
+                    }
+                    Ok(CacheState::None) => {}
+                    Err(err) => return Err(err),
                 }
                 // check ETag is available in the default response.
                 // If so, then we need to set the If-None-Match header.


### PR DESCRIPTION
If the user requests a refresh of the cache we
will still get the ETag if the resource still
exists locally. Before, the optional and user
triggered refresh involved bypassing the cache.