### PR TITLE
Use csv serializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +894,7 @@ dependencies = [
  "chrono",
  "clap",
  "console",
+ "csv",
  "derive_builder",
  "dialoguer",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0.81"
 flate2 = "1.0.28"
 derive_builder = "0.20.0"
 chrono = "0.4.35"
+csv = "1.3.0"
 
 [dev-dependencies]
 # disable basic-cookies from httpmock - not needed

--- a/src/cli/docker.rs
+++ b/src/cli/docker.rs
@@ -32,7 +32,7 @@ struct DockerImageMetadata {
     /// Do not print headers
     #[clap(long)]
     pub no_headers: bool,
-    /// Output format. pipe " | " or csv ","
+    /// Output format
     #[clap(long, default_value_t=FormatCli::Pipe)]
     format: FormatCli,
 }

--- a/src/cmds/cicd.rs
+++ b/src/cmds/cicd.rs
@@ -385,9 +385,9 @@ mod test {
         list_pipelines(Arc::new(pp_remote), body_args, cli_args, &mut buf).unwrap();
         assert_eq!(
             String::from_utf8(buf).unwrap(),
-            "URL | Branch | SHA | Created at | Updated at | Duration | Status\n\
-             https://gitlab.com/owner/repo/-/pipelines/123 | master | 1234567890abcdef | 2020-01-01T00:00:00Z | 2020-01-01T00:01:00Z | 60 | success\n\
-             https://gitlab.com/owner/repo/-/pipelines/456 | master | 1234567890abcdef | 2020-01-01T00:00:00Z | 2020-01-01T00:01:01Z | 61 | failed\n")
+            "URL|Branch|SHA|Created at|Updated at|Duration|Status\n\
+             https://gitlab.com/owner/repo/-/pipelines/123|master|1234567890abcdef|2020-01-01T00:00:00Z|2020-01-01T00:01:00Z|60|success\n\
+             https://gitlab.com/owner/repo/-/pipelines/456|master|1234567890abcdef|2020-01-01T00:00:00Z|2020-01-01T00:01:01Z|61|failed\n")
     }
 
     #[test]
@@ -483,8 +483,8 @@ mod test {
             .unwrap();
         list_pipelines(Arc::new(pp_remote), body_args, cli_args, &mut buf).unwrap();
         assert_eq!(
-            "https://gitlab.com/owner/repo/-/pipelines/123 | master | 1234567890abcdef | 2020-01-01T00:00:00Z | 2020-01-01T00:01:00Z | 60 | success\n\
-             https://gitlab.com/owner/repo/-/pipelines/456 | master | 1234567890abcdef | 2020-01-01T00:00:00Z | 2020-01-01T00:01:00Z | 60 | failed\n",
+            "https://gitlab.com/owner/repo/-/pipelines/123|master|1234567890abcdef|2020-01-01T00:00:00Z|2020-01-01T00:01:00Z|60|success\n\
+             https://gitlab.com/owner/repo/-/pipelines/456|master|1234567890abcdef|2020-01-01T00:00:00Z|2020-01-01T00:01:00Z|60|failed\n",
             String::from_utf8(buf).unwrap(),
         )
     }
@@ -571,9 +571,9 @@ mod test {
             .unwrap();
         list_runners(Arc::new(remote), body_args, cli_args, &mut buf).unwrap();
         assert_eq!(
-            "ID | Active | Description | IP Address | Name | Paused | Shared | Type | Online | Status\n\
-             1 | true | Runner 1 | 10.0.0.1 | runner1 | false | true | shared | true | online\n\
-             2 | true | Runner 2 | 10.0.0.2 | runner2 | false | true | shared | true | online\n",
+            "ID|Active|Description|IP Address|Name|Paused|Shared|Type|Online|Status\n\
+             1|true|Runner 1|10.0.0.1|runner1|false|true|shared|true|online\n\
+             2|true|Runner 2|10.0.0.2|runner2|false|true|shared|true|online\n",
             String::from_utf8(buf).unwrap()
         )
     }
@@ -604,8 +604,8 @@ mod test {
             .unwrap();
         get_runner_details(Arc::new(remote), cli_args, &mut buf).unwrap();
         assert_eq!(
-            "ID | Run untagged | Tags | Architecture | Platform | Contacted at | Version | Revision\n\
-             1 | true | tag1, tag2 | amd64 | linux | 2020-01-01T00:00:00Z | 13.0.0 | 1234567890abcdef\n",
+            "ID|Run untagged|Tags|Architecture|Platform|Contacted at|Version|Revision\n\
+             1|true|tag1, tag2|amd64|linux|2020-01-01T00:00:00Z|13.0.0|1234567890abcdef\n",
             String::from_utf8(buf).unwrap()
         )
     }

--- a/src/cmds/docker.rs
+++ b/src/cmds/docker.rs
@@ -320,8 +320,8 @@ mod tests {
         let mut buf = Vec::new();
         validate_and_list(remote, args, &mut buf).unwrap();
         assert_eq!(
-            "ID | Location | Tags count | Created at\n\
-             1 | registry.gitlab.com/namespace/project | 10 | 2021-01-01T00:00:00Z\n",
+            "ID|Location|Tags count|Created at\n\
+             1|registry.gitlab.com/namespace/project|10|2021-01-01T00:00:00Z\n",
             String::from_utf8(buf).unwrap()
         );
     }
@@ -344,8 +344,8 @@ mod tests {
         let mut buf = Vec::new();
         validate_and_list(remote, args, &mut buf).unwrap();
         assert_eq!(
-            "Name | Path | Location\n\
-            v0.0.1 | namespace/project:v0.0.1 | registry.gitlab.com/namespace/project:v0.0.1\n",
+            "Name|Path|Location\n\
+            v0.0.1|namespace/project:v0.0.1|registry.gitlab.com/namespace/project:v0.0.1\n",
             String::from_utf8(buf).unwrap()
         );
     }
@@ -411,7 +411,7 @@ mod tests {
         let mut buf = Vec::new();
         validate_and_list(remote, args, &mut buf).unwrap();
         assert_eq!(
-            "v0.0.1 | namespace/project:v0.0.1 | registry.gitlab.com/namespace/project:v0.0.1\n",
+            "v0.0.1|namespace/project:v0.0.1|registry.gitlab.com/namespace/project:v0.0.1\n",
             String::from_utf8(buf).unwrap()
         );
     }
@@ -435,7 +435,7 @@ mod tests {
         let mut buf = Vec::new();
         validate_and_list(remote, args, &mut buf).unwrap();
         assert_eq!(
-            "1 | registry.gitlab.com/namespace/project | 10 | 2021-01-01T00:00:00Z\n",
+            "1|registry.gitlab.com/namespace/project|10|2021-01-01T00:00:00Z\n",
             String::from_utf8(buf).unwrap()
         );
     }
@@ -509,8 +509,8 @@ mod tests {
         let mut buf = Vec::new();
         get_image_metadata(remote, args, &mut buf).unwrap();
         assert_eq!(
-            "Name | Location | Short SHA | Size | Created at\n\
-            v0.0.1 | registry.gitlab.com/namespace/project:v0.0.1 | 12345678 | 100 | 2021-01-01T00:00:00Z\n",
+            "Name|Location|Short SHA|Size|Created at\n\
+            v0.0.1|registry.gitlab.com/namespace/project:v0.0.1|12345678|100|2021-01-01T00:00:00Z\n",
             String::from_utf8(buf).unwrap()
         );
     }
@@ -528,7 +528,7 @@ mod tests {
         let mut buf = Vec::new();
         get_image_metadata(remote, args, &mut buf).unwrap();
         assert_eq!(
-            "v0.0.1 | registry.gitlab.com/namespace/project:v0.0.1 | 12345678 | 100 | 2021-01-01T00:00:00Z\n",
+            "v0.0.1|registry.gitlab.com/namespace/project:v0.0.1|12345678|100|2021-01-01T00:00:00Z\n",
             String::from_utf8(buf).unwrap()
         );
     }

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -587,8 +587,8 @@ mod tests {
         );
         list(remote, body_args, cli_args, &mut buf).unwrap();
         assert_eq!(
-            "ID | Title | Author | URL | Updated at\n\
-             1 | New feature | author | https://gitlab.com/owner/repo/-/merge_requests/1 | 2021-01-01\n",
+            "ID|Title|Author|URL|Updated at\n\
+             1|New feature|author|https://gitlab.com/owner/repo/-/merge_requests/1|2021-01-01\n",
             String::from_utf8(buf).unwrap(),
         )
     }
@@ -645,7 +645,7 @@ mod tests {
         );
         list(remote, body_args, cli_args, &mut buf).unwrap();
         assert_eq!(
-            "1 | New feature | author | https://gitlab.com/owner/repo/-/merge_requests/1 | 2021-01-01\n",
+            "1|New feature|author|https://gitlab.com/owner/repo/-/merge_requests/1|2021-01-01\n",
             String::from_utf8(buf).unwrap(),
         )
     }

--- a/src/cmds/release.rs
+++ b/src/cmds/release.rs
@@ -139,7 +139,7 @@ mod test {
         let mut writer = Vec::new();
         list_releases(remote, body_args, cli_args, &mut writer).unwrap();
         assert_eq!(
-            "Tag | Title | Description | URL | ID | Created At | Updated At\nv1.0.0 | First release | Initial release | https://github.com/jordilin/githapi/releases/tag/v0.1.20 | 1 | 2021-01-01T00:00:00Z | 2021-01-01T00:00:01Z\n",
+            "Tag|Title|Description|URL|ID|Created At|Updated At\nv1.0.0|First release|Initial release|https://github.com/jordilin/githapi/releases/tag/v0.1.20|1|2021-01-01T00:00:00Z|2021-01-01T00:00:01Z\n",
             String::from_utf8(writer).unwrap(),
         );
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use std::{collections::HashMap, fmt::Display, io::Write};
+use std::{collections::HashMap, io::Write};
 
 #[derive(Clone, Debug, Default)]
 pub enum Format {
@@ -7,16 +7,6 @@ pub enum Format {
     JSON,
     #[default]
     PIPE,
-}
-
-impl Display for Format {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Format::CSV => write!(f, ","),
-            Format::PIPE => write!(f, "|"),
-            Format::JSON => write!(f, ""),
-        }
-    }
 }
 
 impl From<&Format> for u8 {

--- a/src/display.rs
+++ b/src/display.rs
@@ -13,18 +13,8 @@ impl Display for Format {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Format::CSV => write!(f, ","),
-            Format::PIPE => write!(f, " | "),
+            Format::PIPE => write!(f, "|"),
             Format::JSON => write!(f, ""),
-        }
-    }
-}
-
-impl From<&Format> for &str {
-    fn from(f: &Format) -> Self {
-        match f {
-            Format::CSV => ",",
-            Format::PIPE => " | ",
-            Format::JSON => "",
         }
     }
 }


### PR DESCRIPTION
Also, when using pipe delimiter, i.e " | " remove whitespace to ease on
splitting fields when used in combination of other programs such as awk.