### PR TITLE
Gitlab runners filter by tags

### DIFF
--- a/src/cli/cicd.rs
+++ b/src/cli/cicd.rs
@@ -103,7 +103,7 @@ impl From<RunnerStatusCli> for RunnerStatus {
 impl From<ListRunner> for RunnerOptions {
     fn from(options: ListRunner) -> Self {
         let tags = if let Some(tags) = options.tags {
-            Some(tags.into_iter().map(|tag| tag.trim().to_string()).collect())
+            Some(tags.join(",").to_string())
         } else {
             None
         };

--- a/src/cli/cicd.rs
+++ b/src/cli/cicd.rs
@@ -102,15 +102,10 @@ impl From<RunnerStatusCli> for RunnerStatus {
 
 impl From<ListRunner> for RunnerOptions {
     fn from(options: ListRunner) -> Self {
-        let tags = if let Some(tags) = options.tags {
-            Some(tags.join(",").to_string())
-        } else {
-            None
-        };
         RunnerOptions::List(
             RunnerListCliArgs::builder()
                 .status(options.status.into())
-                .tags(tags)
+                .tags(options.tags.map(|tags| tags.join(",").to_string()))
                 .list_args(gen_list_args(options.list_args))
                 .build()
                 .unwrap(),

--- a/src/cli/cicd.rs
+++ b/src/cli/cicd.rs
@@ -43,8 +43,8 @@ struct ListRunner {
     #[clap()]
     status: RunnerStatusCli,
     /// Comma separated list of tags
-    #[clap(long)]
-    tags: Option<String>,
+    #[clap(long, value_delimiter = ',')]
+    tags: Option<Vec<String>>,
     #[command(flatten)]
     list_args: ListArgs,
 }
@@ -102,10 +102,15 @@ impl From<RunnerStatusCli> for RunnerStatus {
 
 impl From<ListRunner> for RunnerOptions {
     fn from(options: ListRunner) -> Self {
+        let tags = if let Some(tags) = options.tags {
+            Some(tags.into_iter().map(|tag| tag.trim().to_string()).collect())
+        } else {
+            None
+        };
         RunnerOptions::List(
             RunnerListCliArgs::builder()
                 .status(options.status.into())
-                .tags(options.tags)
+                .tags(tags)
                 .list_args(gen_list_args(options.list_args))
                 .build()
                 .unwrap(),

--- a/src/gitlab/cicd.rs
+++ b/src/gitlab/cicd.rs
@@ -76,7 +76,7 @@ impl<R> Gitlab<R> {
             url.push_str("&page=1");
         }
         if let Some(tags) = &args.tags {
-            url.push_str(&format!("?tag_list={}", tags));
+            url.push_str(&format!("&tag_list={}", tags));
         }
         url
     }
@@ -480,7 +480,7 @@ mod test {
             .unwrap();
         gitlab.list(body_args).unwrap();
         assert_eq!(
-            "https://gitlab.com/api/v4/projects/jordilin%2Fgitlapi/runners?status=online?tag_list=tag1,tag2",
+            "https://gitlab.com/api/v4/projects/jordilin%2Fgitlapi/runners?status=online&tag_list=tag1,tag2",
             *client.url(),
         );
         assert_eq!("1234", client.headers().get("PRIVATE-TOKEN").unwrap());

--- a/src/gitlab/cicd.rs
+++ b/src/gitlab/cicd.rs
@@ -75,6 +75,9 @@ impl<R> Gitlab<R> {
         if num_pages {
             url.push_str("&page=1");
         }
+        if let Some(tags) = &args.tags {
+            url.push_str(&format!("?tag_list={}", tags));
+        }
         url
     }
 }
@@ -449,6 +452,37 @@ mod test {
             Box::new(Gitlab::new(config, &domain, &path, client.clone()));
         gitlab.get(11573930).unwrap();
         assert_eq!("https://gitlab.com/api/v4/runners/11573930", *client.url(),);
+        assert_eq!("1234", client.headers().get("PRIVATE-TOKEN").unwrap());
+        assert_eq!(Some(ApiOperation::Pipeline), *client.api_operation.borrow());
+    }
+
+    #[test]
+    fn test_list_gitlab_runners_with_a_tag_list() {
+        let config = config();
+        let domain = "gitlab.com".to_string();
+        let path = "jordilin/gitlapi".to_string();
+        let response = Response::builder()
+            .status(200)
+            .body(get_contract(
+                ContractType::Gitlab,
+                "list_project_runners.json",
+            ))
+            .build()
+            .unwrap();
+        let client = Arc::new(MockRunner::new(vec![response]));
+        let gitlab: Box<dyn CicdRunner> =
+            Box::new(Gitlab::new(config, &domain, &path, client.clone()));
+        let body_args = RunnerListBodyArgs::builder()
+            .status(RunnerStatus::Online)
+            .list_args(None)
+            .tags(Some("tag1,tag2".to_string()))
+            .build()
+            .unwrap();
+        gitlab.list(body_args).unwrap();
+        assert_eq!(
+            "https://gitlab.com/api/v4/projects/jordilin%2Fgitlapi/runners?status=online?tag_list=tag1,tag2",
+            *client.url(),
+        );
         assert_eq!("1234", client.headers().get("PRIVATE-TOKEN").unwrap());
         assert_eq!(Some(ApiOperation::Pipeline), *client.api_operation.borrow());
     }


### PR DESCRIPTION
Implement Gitlab list runners filter by tags:

Ex:

`gr pp rn list --tags tag1,tag2`