### PR TITLE
Create comment on merge request timeline

### DIFF
--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -5,6 +5,7 @@ use crate::{
     cmds::{
         cicd::{Pipeline, PipelineBodyArgs, Runner, RunnerListBodyArgs, RunnerMetadata},
         docker::{DockerListBodyArgs, ImageMetadata, RegistryRepository, RepositoryTag},
+        merge_request::CommentMergeRequestBodyArgs,
         my::User,
         release::{Release, ReleaseBodyArgs},
     },
@@ -64,6 +65,10 @@ pub trait ContainerRegistry {
     fn num_pages_repository_tags(&self, repository_id: i64) -> Result<Option<u32>>;
     fn num_pages_repositories(&self) -> Result<Option<u32>>;
     fn get_image_metadata(&self, repository_id: i64, tag: &str) -> Result<ImageMetadata>;
+}
+
+pub trait CommentMergeRequest {
+    fn create(&self, args: CommentMergeRequestBodyArgs) -> Result<()>;
 }
 
 /// Types of API resources attached to a request. The request will carry this

--- a/src/cli/merge_request.rs
+++ b/src/cli/merge_request.rs
@@ -3,7 +3,9 @@ use std::option::Option;
 use clap::{Parser, ValueEnum};
 
 use crate::{
-    cmds::merge_request::{MergeRequestCliArgs, MergeRequestListCliArgs},
+    cmds::merge_request::{
+        CommentMergeRequestCliArgs, MergeRequestCliArgs, MergeRequestListCliArgs,
+    },
     remote::MergeRequestState,
 };
 use common::ListArgs;
@@ -165,9 +167,7 @@ impl From<MergeRequestCommand> for MergeRequestOptions {
             MergeRequestSubcommand::Merge(options) => options.into(),
             MergeRequestSubcommand::Checkout(options) => options.into(),
             MergeRequestSubcommand::Close(options) => options.into(),
-            MergeRequestSubcommand::Comment(_options) => {
-                todo!("Implement comment merge request")
-            }
+            MergeRequestSubcommand::Comment(options) => options.into(),
         }
     }
 }
@@ -193,9 +193,23 @@ impl From<CreateMergeRequest> for MergeRequestOptions {
     }
 }
 
+impl From<CommentMergeRequest> for MergeRequestOptions {
+    fn from(options: CommentMergeRequest) -> Self {
+        MergeRequestOptions::Comment(
+            CommentMergeRequestCliArgs::builder()
+                .id(options.id)
+                .comment(options.comment)
+                .comment_from_file(options.comment_from_file)
+                .build()
+                .unwrap(),
+        )
+    }
+}
+
 pub enum MergeRequestOptions {
     Create(MergeRequestCliArgs),
     List(MergeRequestListCliArgs),
+    Comment(CommentMergeRequestCliArgs),
     Merge { id: i64 },
     Checkout { id: i64 },
     Close { id: i64 },

--- a/src/cli/merge_request.rs
+++ b/src/cli/merge_request.rs
@@ -28,6 +28,21 @@ enum MergeRequestSubcommand {
     Checkout(CheckoutMergeRequest),
     #[clap(about = "Close a merge request")]
     Close(CloseMergeRequest),
+    #[clap(about = "Comment on a merge request")]
+    Comment(CommentMergeRequest),
+}
+
+#[derive(Parser)]
+struct CommentMergeRequest {
+    /// Id of the merge request
+    #[clap(long)]
+    pub id: i64,
+    /// Comment to add to the merge request
+    #[clap(group = "comment_msg")]
+    pub comment: Option<String>,
+    /// Gather comment from the specified file. If "-" is provided, read from STDIN
+    #[clap(long, value_name = "FILE", group = "comment_msg")]
+    pub comment_from_file: Option<String>,
 }
 
 #[derive(Parser)]
@@ -150,6 +165,9 @@ impl From<MergeRequestCommand> for MergeRequestOptions {
             MergeRequestSubcommand::Merge(options) => options.into(),
             MergeRequestSubcommand::Checkout(options) => options.into(),
             MergeRequestSubcommand::Close(options) => options.into(),
+            MergeRequestSubcommand::Comment(_options) => {
+                todo!("Implement comment merge request")
+            }
         }
     }
 }

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -148,7 +148,19 @@ pub fn execute(
             close(remote, id)
         }
         MergeRequestOptions::Comment(cli_args) => {
-            todo!()
+            let remote = remote::get_comment_mr(domain, path, config, false)?;
+            if let Some(comment_file) = &cli_args.comment_from_file {
+                if comment_file == "-" {
+                    return create_comment(remote, cli_args, Some(std::io::stdin()));
+                } else {
+                    let file = File::open(comment_file).err_context(
+                        GRError::PreconditionNotMet(format!("Cannot open file {}", comment_file)),
+                    )?;
+                    create_comment(remote, cli_args, Some(BufReader::new(file)))
+                }
+            } else {
+                create_comment(remote, cli_args, None::<Cursor<&str>>)
+            }
         }
     }
 }

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -53,6 +53,25 @@ impl MergeRequestListCliArgs {
     }
 }
 
+#[derive(Builder)]
+pub struct CommentMergeRequestCliArgs {
+    pub id: i64,
+    pub comment: Option<String>,
+    pub comment_from_file: Option<String>,
+}
+
+impl CommentMergeRequestCliArgs {
+    pub fn builder() -> CommentMergeRequestCliArgsBuilder {
+        CommentMergeRequestCliArgsBuilder::default()
+    }
+}
+
+#[derive(Builder)]
+pub struct CommentMergeRequestBodyArgs {
+    pub id: i64,
+    pub comment: String,
+}
+
 pub fn execute(
     options: MergeRequestOptions,
     config: Arc<Config>,
@@ -121,6 +140,9 @@ pub fn execute(
         MergeRequestOptions::Close { id } => {
             let remote = remote::get_mr(domain, path, config, false)?;
             close(remote, id)
+        }
+        MergeRequestOptions::Comment(_cli_args) => {
+            todo!()
         }
     }
 }

--- a/src/github/merge_request.rs
+++ b/src/github/merge_request.rs
@@ -1,7 +1,8 @@
 use super::Github;
 use crate::{
-    api_traits::{ApiOperation, MergeRequest, RemoteProject},
+    api_traits::{ApiOperation, CommentMergeRequest, MergeRequest, RemoteProject},
     cli::browse::BrowseOptions,
+    cmds::merge_request::CommentMergeRequestBodyArgs,
     http::{
         Body,
         Method::{GET, PATCH, POST, PUT},
@@ -232,6 +233,12 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Github<R> {
         let url = self.url_list_merge_requests(&args) + "&page=1";
         let headers = self.request_headers();
         query::num_pages(&self.runner, &url, headers, ApiOperation::MergeRequest)
+    }
+}
+
+impl<R: HttpRunner<Response = Response>> CommentMergeRequest for Github<R> {
+    fn create(&self, _args: CommentMergeRequestBodyArgs) -> Result<()> {
+        todo!()
     }
 }
 

--- a/src/github/merge_request.rs
+++ b/src/github/merge_request.rs
@@ -237,8 +237,22 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Github<R> {
 }
 
 impl<R: HttpRunner<Response = Response>> CommentMergeRequest for Github<R> {
-    fn create(&self, _args: CommentMergeRequestBodyArgs) -> Result<()> {
-        todo!()
+    fn create(&self, args: CommentMergeRequestBodyArgs) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/issues/{}/comments",
+            self.rest_api_basepath, self.path, args.id
+        );
+        let mut body = Body::new();
+        body.add("body", args.comment);
+        query::create_merge_request_comment(
+            &self.runner,
+            &url,
+            Some(body),
+            self.request_headers(),
+            POST,
+            ApiOperation::MergeRequest,
+        )?;
+        Ok(())
     }
 }
 
@@ -575,5 +589,47 @@ mod test {
             Some(ApiOperation::MergeRequest),
             *client.api_operation.borrow()
         );
+    }
+
+    #[test]
+    fn test_create_merge_request_comment() {
+        let config = config();
+        let domain = "github.com".to_string();
+        let path = "jordilin/githapi";
+        let response = Response::builder().status(201).build().unwrap();
+        let client = Arc::new(MockRunner::new(vec![response]));
+        let github: Box<dyn CommentMergeRequest> =
+            Box::new(Github::new(config, &domain, &path, client.clone()));
+        let args = CommentMergeRequestBodyArgs::builder()
+            .id(23)
+            .comment("Looks good to me".to_string())
+            .build()
+            .unwrap();
+        github.create(args).unwrap();
+        assert_eq!(
+            "https://api.github.com/repos/jordilin/githapi/issues/23/comments",
+            *client.url(),
+        );
+        assert_eq!(
+            Some(ApiOperation::MergeRequest),
+            *client.api_operation.borrow()
+        );
+    }
+
+    #[test]
+    fn test_create_merge_request_comment_error_status_code() {
+        let config = config();
+        let domain = "github.com".to_string();
+        let path = "jordilin/githapi";
+        let response = Response::builder().status(500).build().unwrap();
+        let client = Arc::new(MockRunner::new(vec![response]));
+        let github: Box<dyn CommentMergeRequest> =
+            Box::new(Github::new(config, &domain, &path, client.clone()));
+        let args = CommentMergeRequestBodyArgs::builder()
+            .id(23)
+            .comment("Looks good to me".to_string())
+            .build()
+            .unwrap();
+        assert!(github.create(args).is_err());
     }
 }

--- a/src/gitlab/merge_request.rs
+++ b/src/gitlab/merge_request.rs
@@ -155,7 +155,22 @@ impl<R> Gitlab<R> {
 
 impl<R: HttpRunner<Response = Response>> CommentMergeRequest for Gitlab<R> {
     fn create(&self, args: CommentMergeRequestBodyArgs) -> Result<()> {
-        todo!()
+        let url = format!(
+            "{}/merge_requests/{}/notes",
+            self.rest_api_basepath(),
+            args.id
+        );
+        let mut body = Body::new();
+        body.add("body", args.comment);
+        query::create_merge_request_comment(
+            &self.runner,
+            &url,
+            Some(body),
+            self.headers(),
+            http::Method::POST,
+            ApiOperation::MergeRequest,
+        )?;
+        Ok(())
     }
 }
 
@@ -443,5 +458,47 @@ mod test {
             .build()
             .unwrap();
         assert_eq!(None, gitlab.num_pages(body_args).unwrap());
+    }
+
+    #[test]
+    fn test_gitlab_create_merge_request_comment_ok() {
+        let config = config();
+        let domain = "gitlab.com".to_string();
+        let path = "jordilin/gitlapi".to_string();
+        let response = Response::builder().status(201).build().unwrap();
+        let client = Arc::new(MockRunner::new(vec![response]));
+        let gitlab: Box<dyn CommentMergeRequest> =
+            Box::new(Gitlab::new(config, &domain, &path, client.clone()));
+        let comment_args = CommentMergeRequestBodyArgs::builder()
+            .id(1456)
+            .comment("LGTM, ship it".to_string())
+            .build()
+            .unwrap();
+        gitlab.create(comment_args).unwrap();
+        assert_eq!(
+            "https://gitlab.com/api/v4/projects/jordilin%2Fgitlapi/merge_requests/1456/notes",
+            *client.url()
+        );
+        assert_eq!(
+            Some(ApiOperation::MergeRequest),
+            *client.api_operation.borrow()
+        );
+    }
+
+    #[test]
+    fn test_gitlab_create_merge_request_comment_error() {
+        let config = config();
+        let domain = "gitlab.com".to_string();
+        let path = "jordilin/gitlapi".to_string();
+        let response = Response::builder().status(400).build().unwrap();
+        let client = Arc::new(MockRunner::new(vec![response]));
+        let gitlab: Box<dyn CommentMergeRequest> =
+            Box::new(Gitlab::new(config, &domain, &path, client.clone()));
+        let comment_args = CommentMergeRequestBodyArgs::builder()
+            .id(1456)
+            .comment("LGTM, ship it".to_string())
+            .build()
+            .unwrap();
+        assert!(gitlab.create(comment_args).is_err());
     }
 }

--- a/src/gitlab/merge_request.rs
+++ b/src/gitlab/merge_request.rs
@@ -1,4 +1,5 @@
-use crate::api_traits::ApiOperation;
+use crate::api_traits::{ApiOperation, CommentMergeRequest};
+use crate::cmds::merge_request::CommentMergeRequestBodyArgs;
 use crate::error;
 use crate::http::Method::GET;
 use crate::http::{self, Body, Headers};
@@ -149,6 +150,12 @@ impl<R> Gitlab<R> {
             url.push_str("&page=1");
         }
         url
+    }
+}
+
+impl<R: HttpRunner<Response = Response>> CommentMergeRequest for Gitlab<R> {
+    fn create(&self, args: CommentMergeRequestBodyArgs) -> Result<()> {
+        todo!()
     }
 }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,7 +1,8 @@
 use std::fmt::{self, Display, Formatter};
 
 use crate::api_traits::{
-    Cicd, CicdRunner, ContainerRegistry, Deploy, MergeRequest, RemoteProject, Timestamp, UserInfo,
+    Cicd, CicdRunner, CommentMergeRequest, ContainerRegistry, Deploy, MergeRequest, RemoteProject,
+    Timestamp, UserInfo,
 };
 use crate::cache::filesystem::FileCache;
 use crate::config::Config;
@@ -479,6 +480,7 @@ get!(get_registry, ContainerRegistry);
 get!(get_deploy, Deploy);
 get!(get_auth_user, UserInfo);
 get!(get_cicd_runner, CicdRunner);
+get!(get_comment_mr, CommentMergeRequest);
 
 #[cfg(test)]
 mod test {

--- a/src/remote/query.rs
+++ b/src/remote/query.rs
@@ -281,3 +281,5 @@ send!(
     GitlabRunnerMetadataFields,
     RunnerMetadata
 );
+
+send!(create_merge_request_comment, Response);


### PR DESCRIPTION
Provide command `gr mr comment --id <id> "message"` to comment on a pull request
timeline.