### PR TITLE
Do no throw error if page headers not available in --num-pages

### DIFF
--- a/src/github/cicd.rs
+++ b/src/github/cicd.rs
@@ -261,7 +261,7 @@ mod test {
         let response = Response::builder().status(200).build().unwrap();
         let client = Arc::new(MockRunner::new(vec![response]));
         let github: Box<dyn Cicd> = Box::new(Github::new(config, &domain, &path, client.clone()));
-        assert!(github.num_pages().is_err());
+        assert_eq!(Some(1), github.num_pages().unwrap());
     }
 
     #[test]

--- a/src/gitlab/merge_request.rs
+++ b/src/gitlab/merge_request.rs
@@ -457,7 +457,7 @@ mod test {
             .assignee_id(None)
             .build()
             .unwrap();
-        assert!(gitlab.num_pages(body_args).is_err());
+        assert_eq!(Some(1), gitlab.num_pages(body_args).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Fixes Github not returning page headers when there
is only one available.