### PR TITLE
Provide a global --repo <domain/owner/repo> flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,7 @@ pub mod star;
 use self::browse::BrowseCommand;
 use self::browse::BrowseOptions;
 use self::cicd::{PipelineCommand, PipelineOptions};
+use self::common::validate_domain_project_repo_path;
 use self::docker::{DockerCommand, DockerOptions};
 use self::init::{InitCommand, InitCommandOptions};
 use self::my::MyCommand;
@@ -40,6 +41,14 @@ struct Args {
     /// Verbose mode. Enable gitar's logging
     #[clap(long, short, global = true)]
     verbose: bool,
+    /// Bypass local .git/config. Use repo instead. Ex: github.com/jordilin/gitar
+    #[clap(
+        long,
+        global = true,
+        value_name = "DOMAIN/OWNER/PROJECT_NAME",
+        value_parser = validate_domain_project_repo_path
+    )]
+    pub repo: Option<String>,
 }
 
 #[derive(Parser)]
@@ -81,7 +90,7 @@ pub fn parse_cli() -> OptionArgs {
         Command::Release(sub_matches) => Some(CliOptions::Release(sub_matches.into())),
         Command::My(sub_matches) => Some(CliOptions::My(sub_matches.into())),
     };
-    OptionArgs::new(options, CliArgs::new(args.verbose))
+    OptionArgs::new(options, CliArgs::new(args.verbose, args.repo))
 }
 
 pub enum CliOptions {
@@ -95,14 +104,15 @@ pub enum CliOptions {
     My(MyOptions),
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct CliArgs {
     pub verbose: bool,
+    pub repo: Option<String>,
 }
 
 impl CliArgs {
-    pub fn new(verbose: bool) -> Self {
-        CliArgs { verbose }
+    pub fn new(verbose: bool, repo: Option<String>) -> Self {
+        CliArgs { verbose, repo }
     }
 }
 

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -1,5 +1,6 @@
 use crate::api_traits::{CommentMergeRequest, MergeRequest, RemoteProject, Timestamp};
 use crate::cli::merge_request::MergeRequestOptions;
+use crate::cli::CliArgs;
 use crate::config::{Config, ConfigProperties};
 use crate::display::{Column, DisplayBody};
 use crate::error::{AddContext, GRError};
@@ -154,12 +155,19 @@ impl From<Comment> for DisplayBody {
 
 pub fn execute(
     options: MergeRequestOptions,
+    global_args: CliArgs,
     config: Arc<Config>,
     domain: String,
     path: String,
 ) -> Result<()> {
     match options {
         MergeRequestOptions::Create(cli_args) => {
+            if global_args.repo.is_some() {
+                return Err(GRError::PreconditionNotMet(
+                    "--repo not allowed when creating a merge request".to_string(),
+                )
+                .into());
+            }
             let mr_remote = remote::get_mr(
                 domain.clone(),
                 path.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
         let f = File::open(config_file).expect("Unable to open file");
 
         let (domain, path) = if cli_args.repo.is_some() {
-            get_domain_path(&cli_args.repo.unwrap())
+            get_domain_path(cli_args.repo.as_ref().unwrap())
         } else {
             let CmdInfo::RemoteUrl { domain, path } = git::remote_url(&Shell)? else {
                 return Err(error::gen("No remote url found. Please set a remote url."));
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
         let config = Arc::new(gr::config::Config::new(f, &domain).expect("Unable to read config"));
         match cli_options {
             CliOptions::MergeRequest(options) => {
-                merge_request::execute(options, config, domain, path)
+                merge_request::execute(options, cli_args, config, domain, path)
             }
             CliOptions::Browse(options) => {
                 // Use default config for browsing - does not require auth.

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -580,6 +580,13 @@ get!(get_auth_user, UserInfo);
 get!(get_cicd_runner, CicdRunner);
 get!(get_comment_mr, CommentMergeRequest);
 
+pub fn get_domain_path(repo_cli: &str) -> (String, String) {
+    let parts: Vec<&str> = repo_cli.split('/').collect();
+    let domain = parts[0].to_string();
+    let path = parts[1..].join("/");
+    (domain, path)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -969,5 +976,13 @@ mod test {
             .add_param("key2", "value2")
             .build();
         assert_eq!(url, "https://example.com?key=value&key2=value2");
+    }
+
+    #[test]
+    fn test_retrieve_domain_path_from_repo_cli_flag() {
+        let repo_cli = "github.com/jordilin/gitar";
+        let (domain, path) = get_domain_path(repo_cli);
+        assert_eq!("github.com", domain);
+        assert_eq!("jordilin/gitar", path);
     }
 }


### PR DESCRIPTION
Allows to query other repositories without the
need to be in the repository directory.