### PR TITLE
Add prerelease column for releases

### DIFF
--- a/src/cmds/release.rs
+++ b/src/cmds/release.rs
@@ -244,7 +244,7 @@ mod test {
         let mut writer = Vec::new();
         list_releases(remote, body_args, cli_args, &mut writer).unwrap();
         assert_eq!(
-            "ID|Tag|Title|Description|URL|Created At|Updated At\n1|v1.0.0|First release|Initial release|https://github.com/jordilin/githapi/releases/tag/v0.1.20|2021-01-01T00:00:00Z|2021-01-01T00:00:01Z\n",
+            "ID|Tag|Title|Description|URL|Prerelease|Created At|Updated At\n1|v1.0.0|First release|Initial release|https://github.com/jordilin/githapi/releases/tag/v0.1.20|false|2021-01-01T00:00:00Z|2021-01-01T00:00:01Z\n",
             String::from_utf8(writer).unwrap(),
         );
     }

--- a/src/cmds/release.rs
+++ b/src/cmds/release.rs
@@ -31,6 +31,8 @@ pub struct Release {
     tag: String,
     title: String,
     description: String,
+    #[builder(default)]
+    prerelease: bool,
     created_at: String,
     updated_at: String,
 }
@@ -49,6 +51,7 @@ impl From<Release> for DisplayBody {
             Column::new("Title", release.title),
             Column::new("Description", release.description),
             Column::new("URL", release.url),
+            Column::new("Prerelease", release.prerelease.to_string()),
             Column::new("Created At", release.created_at),
             Column::new("Updated At", release.updated_at),
         ])
@@ -207,15 +210,18 @@ mod test {
             if self.empty_releases {
                 return Ok(vec![]);
             }
-            Ok(vec![Release {
-                id: String::from("1"),
-                url: String::from("https://github.com/jordilin/githapi/releases/tag/v0.1.20"),
-                tag: String::from("v1.0.0"),
-                title: String::from("First release"),
-                description: String::from("Initial release"),
-                created_at: String::from("2021-01-01T00:00:00Z"),
-                updated_at: String::from("2021-01-01T00:00:01Z"),
-            }])
+            Ok(vec![Release::builder()
+                .id(String::from("1"))
+                .url(String::from(
+                    "https://github.com/jordilin/githapi/releases/tag/v0.1.20",
+                ))
+                .tag(String::from("v1.0.0"))
+                .title(String::from("First release"))
+                .description(String::from("Initial release"))
+                .created_at(String::from("2021-01-01T00:00:00Z"))
+                .updated_at(String::from("2021-01-01T00:00:01Z"))
+                .build()
+                .unwrap()])
         }
 
         fn num_pages(&self) -> Result<Option<u32>> {

--- a/src/github/release.rs
+++ b/src/github/release.rs
@@ -89,41 +89,30 @@ impl<R: HttpRunner<Response = Response>> DeployAsset for Github<R> {
 }
 
 pub struct GithubReleaseFields {
-    id: String,
-    url: String,
-    tag: String,
-    title: String,
-    description: String,
-    created_at: String,
-    updated_at: String,
+    release: Release,
 }
 
 impl From<&serde_json::Value> for GithubReleaseFields {
     fn from(value: &serde_json::Value) -> Self {
         Self {
-            id: value["id"].as_i64().unwrap().to_string(),
-            url: value["html_url"].as_str().unwrap().to_string(),
-            tag: value["tag_name"].as_str().unwrap().to_string(),
-            title: value["name"].as_str().unwrap().to_string(),
-            description: value["body"].as_str().unwrap_or_default().to_string(),
-            created_at: value["created_at"].as_str().unwrap().to_string(),
-            updated_at: value["published_at"].as_str().unwrap().to_string(),
+            release: Release::builder()
+                .id(value["id"].as_i64().unwrap().to_string())
+                .url(value["html_url"].as_str().unwrap().to_string())
+                .tag(value["tag_name"].as_str().unwrap().to_string())
+                .title(value["name"].as_str().unwrap().to_string())
+                .description(value["body"].as_str().unwrap_or_default().to_string())
+                .prerelease(value["prerelease"].as_bool().unwrap_or(false))
+                .created_at(value["created_at"].as_str().unwrap().to_string())
+                .updated_at(value["published_at"].as_str().unwrap().to_string())
+                .build()
+                .unwrap(),
         }
     }
 }
 
 impl From<GithubReleaseFields> for Release {
     fn from(fields: GithubReleaseFields) -> Self {
-        Release::builder()
-            .id(fields.id)
-            .url(fields.url)
-            .tag(fields.tag)
-            .title(fields.title)
-            .description(fields.description)
-            .created_at(fields.created_at)
-            .updated_at(fields.updated_at)
-            .build()
-            .unwrap()
+        fields.release
     }
 }
 

--- a/src/gitlab/release.rs
+++ b/src/gitlab/release.rs
@@ -56,43 +56,32 @@ impl<R: HttpRunner<Response = Response>> DeployAsset for Gitlab<R> {
 }
 
 pub struct GitlabReleaseFields {
-    id: String,
-    url: String,
-    tag: String,
-    title: String,
-    description: String,
-    created_at: String,
-    updated_at: String,
+    release: Release,
 }
 
 impl From<&serde_json::Value> for GitlabReleaseFields {
     fn from(value: &serde_json::Value) -> Self {
         Self {
-            // There's no id available in the response per se. Grab the short commit
-            // id instead
-            id: value["commit"]["short_id"].as_str().unwrap().to_string(),
-            url: value["_links"]["self"].as_str().unwrap().to_string(),
-            tag: value["tag_name"].as_str().unwrap().to_string(),
-            title: value["name"].as_str().unwrap().to_string(),
-            description: value["description"].as_str().unwrap().to_string(),
-            created_at: value["created_at"].as_str().unwrap().to_string(),
-            updated_at: value["released_at"].as_str().unwrap().to_string(),
+            release: Release::builder()
+                // There's no id available in the response per se. Grab the short commit
+                // id instead
+                .id(value["commit"]["short_id"].as_str().unwrap().to_string())
+                .url(value["_links"]["self"].as_str().unwrap().to_string())
+                .tag(value["tag_name"].as_str().unwrap().to_string())
+                .title(value["name"].as_str().unwrap().to_string())
+                .description(value["description"].as_str().unwrap().to_string())
+                .prerelease(value["upcoming_release"].as_bool().unwrap())
+                .created_at(value["created_at"].as_str().unwrap().to_string())
+                .updated_at(value["released_at"].as_str().unwrap().to_string())
+                .build()
+                .unwrap(),
         }
     }
 }
 
 impl From<GitlabReleaseFields> for Release {
     fn from(fields: GitlabReleaseFields) -> Self {
-        Release::builder()
-            .id(fields.id)
-            .url(fields.url)
-            .tag(fields.tag)
-            .title(fields.title)
-            .description(fields.description)
-            .created_at(fields.created_at)
-            .updated_at(fields.updated_at)
-            .build()
-            .unwrap()
+        fields.release
     }
 }
 


### PR DESCRIPTION
Will allow to filter those releases that are not
latest stable. Github sets releases as prerelease
in those that contain a version (semantic version
commonly) + a prerelease version.

Ex. v0.1.0-alpha.1 is a prerelease and the API
sets the prerelease column to true.