### PR TITLE
Provide better domain, path cli handling

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,12 +56,7 @@ struct Args {
     )]
     pub repo: Option<String>,
     /// Bypass local .git/config. Use domain. Ex. for my subcommands
-    #[clap(
-        long,
-        global = true,
-        value_name = "DOMAIN",
-        default_value = "github.com"
-    )]
+    #[clap(long, global = true, value_name = "DOMAIN")]
     pub domain: Option<String>,
     /// Full path to the config location. Default is $HOME/.config/gitar/api
     #[clap(long, global = true, value_name = "PATH")]

--- a/src/cmds/trending.rs
+++ b/src/cmds/trending.rs
@@ -42,9 +42,9 @@ impl From<TrendingProject> for DisplayBody {
     }
 }
 
-pub fn execute(cli_args: TrendingCliArgs, config: Arc<Config>, domain: String) -> Result<()> {
+pub fn execute(cli_args: TrendingCliArgs, config: Arc<Config>, domain: &str) -> Result<()> {
     let remote = remote::get_trending(
-        domain.clone(),
+        domain.to_string(),
         // does not matter in this command. Implementing it for
         // Github.com which is just a query against HTML page.
         "".to_string(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,10 +9,12 @@ use crate::io::RateLimitHeader;
 pub enum GRError {
     #[error("Precondition not met error: {0}")]
     PreconditionNotMet(String),
-    #[error("Remote url not found: {0}")]
+    #[error("Remote url not found. Make sure you are in a git repository: {0}")]
     GitRemoteUrlNotFound(String),
-    #[error("--domain option expected: {0}")]
-    DomainOrRepoExpected(String),
+    #[error("--domain expected: {0}")]
+    DomainExpected(String),
+    #[error("--repo expected: {0}")]
+    RepoExpected(String),
     #[error("Time conversion error: {0}")]
     TimeConversionError(String),
     #[error("Configuration error: {0}")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,65 +1,16 @@
-use std::{fs::File, path::Path, sync::Arc};
+use std::{path::Path, sync::Arc};
 
 use env_logger::Env;
 use gr::{
     cli::{browse::BrowseOptions, parse_cli, trending::TrendingOptions, CliOptions},
     cmds::{self, browse, cicd, docker, merge_request, project},
-    error::GRError,
-    git, init,
-    io::CmdInfo,
-    remote::get_domain_path,
+    init,
+    remote::{self, CliDomainRequirements},
     shell::BlockingCommand,
     Result,
 };
 
 const DEFAULT_CONFIG_PATH: &str = ".config/gitar/api";
-
-fn get_config_domain_path(
-    config_file: &Path,
-    cli_args: &gr::cli::CliArgs,
-    requires_local_repo: bool,
-    read_config: bool,
-) -> Result<(Arc<gr::config::Config>, String, String)> {
-    let (domain, path) = if cli_args.repo.is_some() {
-        get_domain_path(cli_args.repo.as_ref().unwrap())
-    } else if requires_local_repo {
-        match git::remote_url(&BlockingCommand) {
-            Ok(CmdInfo::RemoteUrl { domain, path }) => (domain, path),
-            Err(err) => {
-                return Err(GRError::GitRemoteUrlNotFound(format!(
-                    "{}: {}",
-                    err, "Unable to get the remote url."
-                ))
-                .into())
-            }
-            _ => {
-                return Err(GRError::ApplicationError(
-                    "Could not get remote url during startup. \
-                    main::get_config_domain_path - Please open a bug to \
-                    https://github.com/jordilin/gitar"
-                        .to_string(),
-                )
-                .into())
-            }
-        }
-    } else if cli_args.domain.is_some() {
-        (
-            cli_args.domain.as_ref().unwrap().to_string(),
-            "".to_string(),
-        )
-    } else {
-        return Err(
-            GRError::DomainOrRepoExpected("Missing repository information".to_string()).into(),
-        );
-    };
-    if read_config {
-        let f = File::open(config_file).expect("Unable to open config file");
-        let config = Arc::new(gr::config::Config::new(f, &domain).expect("Unable to read config"));
-        Ok((config, domain, path))
-    } else {
-        Ok((Arc::new(gr::config::Config::default()), domain, path))
-    }
-}
 
 fn main() -> Result<()> {
     let home_dir = std::env::var("HOME").unwrap();
@@ -78,27 +29,10 @@ fn main() -> Result<()> {
         env_logger::init_from_env(env);
     }
     match handle_cli_options(cli_options, config_file, cli_args) {
-        Err(err) => match err.downcast_ref::<GRError>() {
-            Some(GRError::GitRemoteUrlNotFound(msg)) => {
-                eprintln!(
-                    "Please cd into a git repository or set --repo option - {}",
-                    msg
-                );
-                std::process::exit(1);
-            }
-            Some(GRError::DomainOrRepoExpected(msg)) => {
-                eprintln!(
-                    "Please set a domain with --domain flag or cd \
-                into a git repository or set --repo option - {}",
-                    msg
-                );
-                std::process::exit(1);
-            }
-            _ => {
-                eprintln!("{}", err);
-                std::process::exit(1);
-            }
-        },
+        Err(err) => {
+            eprintln!("{}", err);
+            std::process::exit(1);
+        }
         Ok(_) => Ok(()),
     }
 }
@@ -110,51 +44,94 @@ fn handle_cli_options(
 ) -> Result<()> {
     match cli_options {
         CliOptions::MergeRequest(options) => {
-            let (config, domain, path) =
-                get_config_domain_path(&config_file, &cli_args, true, true)?;
+            let requirements = vec![
+                CliDomainRequirements::CdInLocalRepo,
+                CliDomainRequirements::RepoArgs,
+            ];
+            let (domain, path) =
+                remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
+            let config = remote::read_config(&config_file, &domain)?;
             merge_request::execute(options, cli_args, config, domain, path)
         }
         CliOptions::Browse(options) => {
             // Use default config for browsing - does not require auth.
-            let (config, domain, path) =
-                get_config_domain_path(&config_file, &cli_args, true, false)?;
+            let config = Arc::new(gr::config::Config::default());
+            let requirements = vec![
+                CliDomainRequirements::CdInLocalRepo,
+                CliDomainRequirements::RepoArgs,
+            ];
+            let (domain, path) =
+                remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
             browse::execute(options, config, domain, path)
         }
         CliOptions::Pipeline(options) => {
-            let (config, domain, path) =
-                get_config_domain_path(&config_file, &cli_args, true, true)?;
+            let requirements = vec![
+                CliDomainRequirements::CdInLocalRepo,
+                CliDomainRequirements::RepoArgs,
+            ];
+            let (domain, path) =
+                remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
+            let config = remote::read_config(&config_file, &domain)?;
             cicd::execute(options, config, domain, path)
         }
         CliOptions::Project(options) => {
-            let (config, domain, path) =
-                get_config_domain_path(&config_file, &cli_args, true, true)?;
+            let requirements = vec![
+                CliDomainRequirements::CdInLocalRepo,
+                CliDomainRequirements::RepoArgs,
+            ];
+            let (domain, path) =
+                remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
+            let config = remote::read_config(&config_file, &domain)?;
             project::execute(options, config, domain, path)
         }
         CliOptions::Docker(options) => {
-            let (config, domain, path) =
-                get_config_domain_path(&config_file, &cli_args, true, true)?;
+            let requirements = vec![
+                CliDomainRequirements::CdInLocalRepo,
+                CliDomainRequirements::RepoArgs,
+            ];
+            let (domain, path) =
+                remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
+            let config = remote::read_config(&config_file, &domain)?;
             docker::execute(options, config, domain, path)
         }
         CliOptions::Release(options) => {
-            let (config, domain, path) =
-                get_config_domain_path(&config_file, &cli_args, true, true)?;
+            let requirements = vec![
+                CliDomainRequirements::CdInLocalRepo,
+                CliDomainRequirements::RepoArgs,
+            ];
+            let (domain, path) =
+                remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
+            let config = remote::read_config(&config_file, &domain)?;
             cmds::release::execute(options, config, domain, path)
         }
         CliOptions::My(options) => {
-            let (config, domain, path) =
-                get_config_domain_path(&config_file, &cli_args, false, true)?;
+            let requirements = vec![
+                CliDomainRequirements::CdInLocalRepo,
+                CliDomainRequirements::DomainArgs,
+            ];
+            let (domain, path) =
+                remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
+            let config = remote::read_config(&config_file, &domain)?;
             cmds::my::execute(options, config, domain, path)
         }
         CliOptions::Trending(options) => match options {
             TrendingOptions::Get(args) => {
-                let (config, domain, _) =
-                    get_config_domain_path(&config_file, &cli_args, false, true)?;
+                // Trending repos is for github.com - Allow for `gr tr
+                // <language>` everywhere in the shell.
+                let domain = "github.com";
+                let config = remote::read_config(&config_file, domain)?;
                 cmds::trending::execute(args, config, domain)
             }
         },
         CliOptions::Init(options) => init::execute(options, config_file),
         CliOptions::Cache(options) => {
-            let (config, _, _) = get_config_domain_path(&config_file, &cli_args, false, true)?;
+            let requirements = vec![
+                CliDomainRequirements::CdInLocalRepo,
+                CliDomainRequirements::DomainArgs,
+                CliDomainRequirements::RepoArgs,
+            ];
+            let (domain, _) = remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
+            let config = remote::read_config(&config_file, &domain)?;
             cmds::cache::execute(options, config)
         }
         CliOptions::Manual => browse::execute(


### PR DESCRIPTION
This commit provides a better handling when user is not inside a git
repository. Some commands do not need to be in a git repo, while others
might just use --domain or --repo.