### PR TITLE
Update flake.lock + minor syntax update assoc. bounds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714864355,
-        "narHash": "sha256-uXNW6bapWFfkYIkK1EagydSrFMqycOYEDSq75GmUpjk=",
+        "lastModified": 1718078026,
+        "narHash": "sha256-LbQabH6h86ZzTvDnaZHmMwedRZNB2jYtUQzmoqWQoJ8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "442a7a6152f49b907e73206dc8e1f46a61e8e873",
+        "rev": "a3f0c63eed74a516298932b9b1627dd80b9c3892",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714763106,
-        "narHash": "sha256-DrDHo74uTycfpAF+/qxZAMlP/Cpe04BVioJb6fdI0YY=",
+        "lastModified": 1718160348,
+        "narHash": "sha256-9YrUjdztqi4Gz8n3mBuqvCkMo4ojrA6nASwyIKWMpus=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9be42459999a253a9f92559b1f5b72e1b44c13d",
+        "rev": "57d6973abba7ea108bac64ae7629e7431e0199b6",
         "type": "github"
       },
       "original": {

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -640,6 +640,7 @@ fn list_comments<W: Write>(
 #[cfg(test)]
 mod tests {
     use std::{
+        ffi::OsStr,
         io::{Cursor, Read},
         sync::Mutex,
     };
@@ -1044,8 +1045,7 @@ mod tests {
 
         fn run<T>(&self, _cmd: T) -> Result<Self::Response>
         where
-            T: IntoIterator,
-            T::Item: AsRef<std::ffi::OsStr>,
+            T: IntoIterator<Item: AsRef<OsStr>>,
         {
             let response = self.responses.lock().unwrap().pop().unwrap();
             Ok(Response::builder().body(response.body).build().unwrap())

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -17,8 +17,7 @@ impl TaskRunner for BlockingCommand {
 
     fn run<T>(&self, cmd: T) -> Result<Self::Response>
     where
-        T: IntoIterator,
-        T::Item: AsRef<OsStr>,
+        T: IntoIterator<Item: AsRef<OsStr>>,
     {
         run_args(cmd)
     }
@@ -26,8 +25,7 @@ impl TaskRunner for BlockingCommand {
 
 fn run_args<T>(args: T) -> Result<Response>
 where
-    T: IntoIterator,
-    T::Item: AsRef<OsStr>,
+    T: IntoIterator<Item: AsRef<OsStr>>,
 {
     let args: Vec<_> = args.into_iter().collect();
     let mut process = process::Command::new(&args[0]);
@@ -63,8 +61,7 @@ impl TaskRunner for StreamingCommand {
 
     fn run<T>(&self, cmd: T) -> Result<Self::Response>
     where
-        T: IntoIterator,
-        T::Item: AsRef<std::ffi::OsStr>,
+        T: IntoIterator<Item: AsRef<OsStr>>,
     {
         let args: Vec<_> = cmd.into_iter().collect();
         let cmd_path = &args[0];

--- a/src/test.rs
+++ b/src/test.rs
@@ -15,6 +15,7 @@ pub mod utils {
     use serde::Serialize;
     use std::{
         cell::{Ref, RefCell},
+        ffi::OsStr,
         fmt::Write,
         fs::File,
         io::Read,
@@ -106,8 +107,7 @@ pub mod utils {
 
         fn run<T>(&self, cmd: T) -> Result<Self::Response>
         where
-            T: IntoIterator,
-            T::Item: AsRef<std::ffi::OsStr>,
+            T: IntoIterator<Item: AsRef<OsStr>>,
         {
             self.cmd.replace(
                 cmd.into_iter()


### PR DESCRIPTION
In rust 1.79, we can add associated type bounds within a bound, removing
the need to add an extra where clause.