### PR TITLE
Provide amps list/exec command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "git-ar"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-ar"
-version = "0.1.70"
+version = "0.1.71"
 edition = "2021"
 
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ You can download the latest release from the releases page
 <https://github.com/jordilin/gitar/releases> and place the binary anywhere in
 your path.
 
-Or you can build from source.
+Or you can build from source. Building from source requires the latest stable
+release of Rust.
 
 ```bash
 cargo build --release

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -6,3 +6,4 @@
   - [Configuration](./configuration.md)
 - [Gitar commands](./cmds/index.md)
   - [Merge request](./cmds/merge_request.md)
+  - [Amps](./cmds/amps.md)

--- a/doc/src/cmds/amps.md
+++ b/doc/src/cmds/amps.md
@@ -1,0 +1,55 @@
+# gr amps
+
+`gr amps` lists and execute amps. Amps are wrappers around the `gr` command
+itself. Amps normally execute gr subcommands and perform additional logic to get
+to the desired result. They can also be seen as just `gr` scripts that can be
+executed from `gr` itself. A curated list of amps is provided at
+<https://github.com/jordilin/gitar-amps>.
+
+## List available amps
+
+```bash
+gr amps
+```
+
+or
+
+```bash
+gr amps list
+```
+
+## Execute an amp in-line
+
+To execute an amp in-line, you can use the following command:
+
+```bash
+gr amps exec "<amp-name> <arg_0> <arg_1> ... <arg_n>"
+```
+
+For example:
+
+```bash
+gr amps exec "list-last-assets github.com/jordilin/gitar"
+```
+
+will print out the URLs of the last stable release assets for the
+`github.com/jordilin/gitar` repository.
+
+**> Note:** Arguments for the amps are optional and the amp name and its
+arguments should be enclosed in double quotes.
+
+## Execute an amp by prompt
+
+```bash
+gr amps exec
+```
+
+This command will prompt you to select an amp from the list of available amps.
+After selecting the amp name, it will prompt you to enter the arguments for the
+amp. Upon pressing enter, the amp will be executed.
+
+The prompt undertands the following prompt queries once an amp has been
+selected:
+
+- `h` or `help` - Show help message for the selected amp.
+- `q` or `quit` - Quit the prompt and return back to the CLI.

--- a/doc/src/cmds/index.md
+++ b/doc/src/cmds/index.md
@@ -5,6 +5,7 @@
 ## Commands available
 
 - [Merge request](./merge_request.md)
+- [Amps](./amps.md)
 
 All gitar commands have a set of common options that can be used to control
 their behavior.

--- a/justfile
+++ b/justfile
@@ -54,5 +54,8 @@ audit:
     mkdir -p .cargo-audit-db/db
     cargo audit -D warnings -d .cargo-audit-db/db
 
+mdbook-serve:
+    mdbook serve doc --open
+
 doc:
     cargo doc --no-deps --open

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+pub mod amps;
 pub mod browse;
 pub mod cache;
 pub mod cicd;
@@ -23,6 +24,8 @@ use self::project::{ProjectCommand, ProjectOptions};
 use self::release::{ReleaseCommand, ReleaseOptions};
 use self::trending::TrendingCommand;
 use self::trending::TrendingOptions;
+use amps::AmpsCommand;
+use amps::AmpsOptions;
 use cache::CacheCommand;
 use cache::CacheOptions;
 use merge_request::{MergeRequestCommand, MergeRequestOptions};
@@ -89,7 +92,7 @@ enum Command {
     Trending(TrendingCommand),
     /// Interactively execute gitar amplifier commands using gitar. gr-in-gr
     #[clap(name = "amps")]
-    Amps,
+    Amps(AmpsCommand),
     #[clap(name = "init", about = "Initialize the config file")]
     Init(InitCommand),
     #[clap(name = "cache", about = "Local cache operations")]
@@ -117,7 +120,7 @@ pub fn parse_cli() -> OptionArgs {
         Command::Trending(sub_matches) => Some(CliOptions::Trending(sub_matches.into())),
         Command::Cache(sub_matches) => Some(CliOptions::Cache(sub_matches.into())),
         Command::Manual => Some(CliOptions::Manual),
-        Command::Amps => Some(CliOptions::Amps),
+        Command::Amps(sub_matches) => Some(CliOptions::Amps(sub_matches.into())),
     };
     OptionArgs::new(
         options,
@@ -137,7 +140,7 @@ pub enum CliOptions {
     Trending(TrendingOptions),
     Cache(CacheOptions),
     Manual,
-    Amps,
+    Amps(AmpsOptions),
 }
 
 #[derive(Clone)]

--- a/src/cli/amps.rs
+++ b/src/cli/amps.rs
@@ -1,0 +1,83 @@
+use clap::Parser;
+
+#[derive(Parser)]
+pub struct AmpsCommand {
+    #[clap(subcommand)]
+    subcommand: Option<AmpsSubcommand>,
+}
+
+#[derive(Parser)]
+enum AmpsSubcommand {
+    #[clap(about = "List available amps")]
+    List,
+    #[clap(
+        name = "exec",
+        about = "Execute an amp, either by name or through prompt",
+        alias = "ex"
+    )]
+    Exec(ExecCommand),
+}
+
+#[derive(Parser)]
+struct ExecCommand {
+    /// The name of the amp to execute
+    #[clap()]
+    pub name: Option<String>,
+}
+
+pub enum AmpsOptions {
+    List,
+    Exec(String),
+}
+
+impl From<AmpsCommand> for AmpsOptions {
+    fn from(options: AmpsCommand) -> Self {
+        match options.subcommand {
+            Some(AmpsSubcommand::List) => AmpsOptions::List,
+            Some(AmpsSubcommand::Exec(options)) => options.into(),
+            // defaults to list available amps
+            None => AmpsOptions::List,
+        }
+    }
+}
+
+impl From<ExecCommand> for AmpsOptions {
+    fn from(options: ExecCommand) -> Self {
+        match options.name {
+            Some(name) => AmpsOptions::Exec(name),
+            // defaults to execute amp through prompt
+            None => AmpsOptions::Exec(String::new()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cli::{Args, Command};
+
+    use super::*;
+
+    #[test]
+    fn test_amps_list_command() {
+        let args = Args::parse_from(vec!["gr", "amps", "list"]);
+        match args.command {
+            Command::Amps(AmpsCommand {
+                subcommand: Some(AmpsSubcommand::List),
+            }) => {}
+            _ => panic!("Expected Amp ListCommand"),
+        }
+    }
+
+    #[test]
+    fn test_amps_exec_command() {
+        let args = Args::parse_from(vec!["gr", "amps", "exec", "amp-name"]);
+        match args.command {
+            Command::Amps(AmpsCommand {
+                subcommand: Some(AmpsSubcommand::Exec(ExecCommand { name })),
+            }) => {
+                assert_eq!(name, Some("amp-name".to_string()));
+            }
+            _ => panic!("Expected Amp ExecCommand"),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,6 @@ fn handle_cli_options(
             "".to_string(),
             "".to_string(),
         ),
-        CliOptions::Amps => cmds::amps::execute(config_file),
+        CliOptions::Amps(options) => cmds::amps::execute(options, config_file),
     }
 }


### PR DESCRIPTION
Allow for inline execution of an amp by name. That is
`gr amp exec "<amp-name> <args...>"` will execute the amp.