### PR TITLE
http::Request borrows Body

### DIFF
--- a/src/github/merge_request.rs
+++ b/src/github/merge_request.rs
@@ -83,8 +83,7 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Github<R> {
         match query::github_merge_request_response(
             &self.runner,
             &mr_url,
-            // TODO, clone for now as might be needed for amend. Should be ref instead.
-            Some(body.clone()),
+            Some(&body),
             self.request_headers(),
             POST,
             ApiOperation::MergeRequest,
@@ -122,7 +121,7 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Github<R> {
                         query::github_merge_request::<_, &Vec<&str>>(
                             &self.runner,
                             &issues_url,
-                            Some(body),
+                            Some(&body),
                             self.request_headers(),
                             PATCH,
                             ApiOperation::MergeRequest,
@@ -168,7 +167,7 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Github<R> {
                                 query::github_merge_request::<_, String>(
                                     &self.runner,
                                     &url,
-                                    Some(body),
+                                    Some(&body),
                                     self.request_headers(),
                                     PATCH,
                                     ApiOperation::MergeRequest,
@@ -291,7 +290,7 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Github<R> {
         query::github_merge_request::<_, &str>(
             &self.runner,
             &url,
-            Some(body),
+            Some(&body),
             self.request_headers(),
             PATCH,
             ApiOperation::MergeRequest,
@@ -326,7 +325,7 @@ impl<R: HttpRunner<Response = Response>> CommentMergeRequest for Github<R> {
         query::create_merge_request_comment(
             &self.runner,
             &url,
-            Some(body),
+            Some(&body),
             self.request_headers(),
             POST,
             ApiOperation::MergeRequest,

--- a/src/gitlab/cicd.rs
+++ b/src/gitlab/cicd.rs
@@ -47,7 +47,7 @@ impl<R: HttpRunner<Response = Response>> Cicd for Gitlab<R> {
         query::gitlab_lint_ci_file(
             &self.runner,
             &url,
-            Some(payload),
+            Some(&payload),
             self.headers(),
             http::Method::POST,
             ApiOperation::Pipeline,

--- a/src/gitlab/merge_request.rs
+++ b/src/gitlab/merge_request.rs
@@ -53,7 +53,7 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Gitlab<R> {
         let response = query::gitlab_merge_request_response(
             &self.runner,
             &url,
-            Some(body.clone()),
+            Some(&body),
             self.headers(),
             http::Method::POST,
             ApiOperation::MergeRequest,
@@ -81,7 +81,7 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Gitlab<R> {
                 query::gitlab_merge_request_response(
                     &self.runner,
                     &url,
-                    Some(body),
+                    Some(&body),
                     self.headers(),
                     http::Method::PUT,
                     ApiOperation::MergeRequest,
@@ -157,7 +157,7 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Gitlab<R> {
         query::gitlab_merge_request::<_, &str>(
             &self.runner,
             &url,
-            Some(body),
+            Some(&body),
             self.headers(),
             http::Method::PUT,
             ApiOperation::MergeRequest,
@@ -240,7 +240,7 @@ impl<R: HttpRunner<Response = Response>> CommentMergeRequest for Gitlab<R> {
         query::create_merge_request_comment(
             &self.runner,
             &url,
-            Some(body),
+            Some(&body),
             self.headers(),
             http::Method::POST,
             ApiOperation::MergeRequest,

--- a/src/remote/query.rs
+++ b/src/remote/query.rs
@@ -124,7 +124,7 @@ macro_rules! send {
         pub fn $func_name<R: HttpRunner<Response = Response>, T: Serialize>(
             runner: &Arc<R>,
             url: &str,
-            body: Option<Body<T>>,
+            body: Option<&Body<T>>,
             request_headers: Headers,
             method: http::Method,
             operation: ApiOperation,
@@ -138,7 +138,7 @@ macro_rules! send {
         pub fn $func_name<R: HttpRunner<Response = Response>, T: Serialize>(
             runner: &Arc<R>,
             url: &str,
-            body: Option<Body<T>>,
+            body: Option<&Body<T>>,
             request_headers: Headers,
             method: http::Method,
             operation: ApiOperation,
@@ -150,7 +150,7 @@ macro_rules! send {
         pub fn $func_name<R: HttpRunner<Response = Response>, T: Serialize>(
             runner: &Arc<R>,
             url: &str,
-            body: Option<Body<T>>,
+            body: Option<&Body<T>>,
             request_headers: Headers,
             method: http::Method,
             operation: ApiOperation,
@@ -164,7 +164,7 @@ macro_rules! send {
 fn send_request<R: HttpRunner<Response = Response>, T: Serialize>(
     runner: &Arc<R>,
     url: &str,
-    body: Option<Body<T>>,
+    body: Option<&Body<T>>,
     request_headers: Headers,
     method: http::Method,
     operation: ApiOperation,
@@ -284,12 +284,12 @@ macro_rules! paged {
     };
 }
 
-fn build_list_request(
+fn build_list_request<'a>(
     url: &str,
     list_args: &Option<ListBodyArgs>,
     request_headers: Headers,
     operation: ApiOperation,
-) -> Request<()> {
+) -> Request<'a, ()> {
     let mut request: http::Request<()> =
         http::Request::new(url, http::Method::GET).with_api_operation(operation);
     request.set_headers(request_headers);


### PR DESCRIPTION
This will prevent unnecessary clone when doing a merge_request and a
potential --amend is issued. Also, a request does not really need to
take ownership of the client's http body.