### PR TITLE
Allow for no configuration and no caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "git-ar"
-version = "0.1.91"
+version = "0.1.92"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-ar"
-version = "0.1.91"
+version = "0.1.92"
 edition = "2021"
 
 license = "MIT"

--- a/doc/src/configuration.md
+++ b/doc/src/configuration.md
@@ -8,7 +8,7 @@ When I talk about an API call or number of pages, I'm referring to actual
 HTTP requests to the Github or Gitlab API. Hence, when I say an API call or one
 page of information, I'm referring to a single HTTP request.
 
-## Create a configuration file
+## Create a configuration file (Optional)
 
 In order to create a configuration file, you can run the following command. In
 this example we are setting the domain to `github.com`. It can be `gitlab.com`
@@ -23,6 +23,16 @@ directory with some defaults. The configuration follows a properties file format
 with key, value pairs. Once the file is created, open the api file to add your
 API token and the preferred assignee username you want to use in your pull
 requests (traditionally your own username).
+
+### No configuration file
+
+Potential use cases: CI/CD pipelines, automation scripts, one-off runs.
+
+If no configuration file is provided, then gitar expects an authentication token
+environment variable to be set. Check the [API token](#api-token) section for
+more information.
+
+No configuration means that there won't be any caching for read operations either.
 
 ## API token
 

--- a/src/cache/filesystem.rs
+++ b/src/cache/filesystem.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::sync::Arc;
 
 use flate2::bufread::GzDecoder;
 use sha2::{Digest, Sha256};
@@ -19,12 +20,12 @@ use crate::Result;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 
-pub struct FileCache<C> {
-    config: C,
+pub struct FileCache {
+    config: Arc<dyn ConfigProperties>,
 }
 
-impl<C: ConfigProperties> FileCache<C> {
-    pub fn new(config: C) -> Self {
+impl FileCache {
+    pub fn new(config: Arc<dyn ConfigProperties>) -> Self {
         FileCache { config }
     }
 
@@ -32,7 +33,7 @@ impl<C: ConfigProperties> FileCache<C> {
         let mut hasher = Sha256::new();
         hasher.update(url);
         let hash = hasher.finalize();
-        let cache_location = self.config.cache_location();
+        let cache_location = self.config.cache_location().unwrap();
         let location = cache_location.strip_suffix('/').unwrap_or(cache_location);
         format!("{}/{:x}", location, hash)
     }
@@ -104,7 +105,7 @@ impl<C: ConfigProperties> FileCache<C> {
     }
 }
 
-impl<C: ConfigProperties> Cache<Resource> for FileCache<C> {
+impl Cache<Resource> for FileCache {
     fn get(&self, key: &Resource) -> Result<CacheState> {
         let path = self.get_cache_file(&key.url);
         if let Ok(f) = File::open(&path) {
@@ -240,17 +241,17 @@ mod tests {
         fn api_token(&self) -> &str {
             "1234"
         }
-        fn cache_location(&self) -> &str {
+        fn cache_location(&self) -> Option<&str> {
             // TODO test with suffix /
             // should probably be sanitized on the Config struct itself.
-            "/home/user/.cache"
+            Some("/home/user/.cache")
         }
     }
 
     #[test]
     fn test_get_cache_file() {
         let config = ConfigMock::new();
-        let file_cache = FileCache::new(config);
+        let file_cache = FileCache::new(Arc::new(config));
         let url = "https://gitlab.org/api/v4/projects/jordilin%2Fmr";
         let cache_file = file_cache.get_cache_file(url);
         assert_eq!(
@@ -268,7 +269,7 @@ mod tests {
         let mut enc = GzEncoder::new(Vec::new(), Compression::default());
         enc.write_all(cached_data.as_bytes()).unwrap();
         let reader = std::io::Cursor::new(enc.finish().unwrap());
-        let fc = FileCache::new(ConfigMock::new());
+        let fc = FileCache::new(Arc::new(ConfigMock::new()));
         let response = fc.get_cache_data(reader).unwrap();
 
         assert_eq!(200, response.status);

--- a/src/cache/filesystem.rs
+++ b/src/cache/filesystem.rs
@@ -34,7 +34,7 @@ impl FileCache {
         let cache_location = self
             .config
             .cache_location()
-            .ok_or_else(|| GRError::ConfigurationNotFound)?;
+            .ok_or(GRError::ConfigurationNotFound)?;
 
         let path = Path::new(cache_location);
 

--- a/src/cli/merge_request.rs
+++ b/src/cli/merge_request.rs
@@ -313,6 +313,7 @@ pub enum MergeRequestOptions {
     ListComment(CommentMergeRequestListCliArgs),
     Approve { id: i64 },
     Merge { id: i64 },
+    // TODO: Checkout is a read operation, so we should propagate MergeRequestGetCliArgs
     Checkout { id: i64 },
     Close { id: i64 },
 }

--- a/src/cmds/browse.rs
+++ b/src/cmds/browse.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use crate::cli::browse::BrowseOptions;
-use crate::config::Config;
+use crate::config::ConfigFile;
 use crate::remote;
 use crate::Result;
 
 pub fn execute(
     options: BrowseOptions,
-    config: Arc<Config>,
+    config: Arc<ConfigFile>,
     domain: String,
     path: String,
 ) -> Result<()> {

--- a/src/cmds/browse.rs
+++ b/src/cmds/browse.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::cli::browse::BrowseOptions;
 use crate::config::ConfigFile;
 use crate::remote;
+use crate::remote::CacheType;
 use crate::Result;
 
 pub fn execute(
@@ -19,25 +20,25 @@ pub fn execute(
             Ok(open::that(remote_url)?)
         }
         BrowseOptions::MergeRequests => {
-            let remote = remote::get_project(domain, path, config, None)?;
+            let remote = remote::get_project(domain, path, config, None, CacheType::None)?;
             Ok(open::that(remote.get_url(BrowseOptions::MergeRequests))?)
         }
         BrowseOptions::MergeRequestId(id) => {
-            let remote = remote::get_project(domain, path, config, None)?;
+            let remote = remote::get_project(domain, path, config, None, CacheType::None)?;
             Ok(open::that(
                 remote.get_url(BrowseOptions::MergeRequestId(id)),
             )?)
         }
         BrowseOptions::Pipelines => {
-            let remote = remote::get_project(domain, path, config, None)?;
+            let remote = remote::get_project(domain, path, config, None, CacheType::None)?;
             Ok(open::that(remote.get_url(BrowseOptions::Pipelines))?)
         }
         BrowseOptions::PipelineId(id) => {
-            let remote = remote::get_project(domain, path, config, None)?;
+            let remote = remote::get_project(domain, path, config, None, CacheType::None)?;
             Ok(open::that(remote.get_url(BrowseOptions::PipelineId(id)))?)
         }
         BrowseOptions::Releases => {
-            let remote = remote::get_project(domain, path, config, None)?;
+            let remote = remote::get_project(domain, path, config, None, CacheType::None)?;
             Ok(open::that(remote.get_url(BrowseOptions::Releases))?)
         }
         BrowseOptions::Manual => Ok(open::that(crate::USER_GUIDE_URL)?),

--- a/src/cmds/cicd.rs
+++ b/src/cmds/cicd.rs
@@ -3,7 +3,7 @@ use yaml::load_yaml;
 
 use crate::api_traits::{Cicd, CicdJob, CicdRunner, Timestamp};
 use crate::cli::cicd::{JobOptions, PipelineOptions, RunnerOptions};
-use crate::config::Config;
+use crate::config::ConfigProperties;
 use crate::display::{Column, DisplayBody};
 use crate::remote::{GetRemoteCliArgs, ListBodyArgs, ListRemoteCliArgs};
 use crate::{display, error, remote, Result};
@@ -406,7 +406,7 @@ impl JobListBodyArgs {
 
 pub fn execute(
     options: PipelineOptions,
-    config: Arc<Config>,
+    config: Arc<dyn ConfigProperties>,
     domain: String,
     path: String,
 ) -> Result<()> {

--- a/src/cmds/cicd.rs
+++ b/src/cmds/cicd.rs
@@ -5,7 +5,7 @@ use crate::api_traits::{Cicd, CicdJob, CicdRunner, Timestamp};
 use crate::cli::cicd::{JobOptions, PipelineOptions, RunnerOptions};
 use crate::config::ConfigProperties;
 use crate::display::{Column, DisplayBody};
-use crate::remote::{GetRemoteCliArgs, ListBodyArgs, ListRemoteCliArgs};
+use crate::remote::{CacheType, GetRemoteCliArgs, ListBodyArgs, ListRemoteCliArgs};
 use crate::{display, error, remote, Result};
 use std::fmt::Display;
 use std::io::{Read, Write};
@@ -412,13 +412,15 @@ pub fn execute(
 ) -> Result<()> {
     match options {
         PipelineOptions::Lint(args) => {
-            let remote = remote::get_cicd(domain, path, config, None)?;
+            // TODO - should propagage cache args
+            let remote = remote::get_cicd(domain, path, config, None, CacheType::File)?;
             let file = std::fs::File::open(args.path)?;
             let body = read_ci_file(file)?;
             lint_ci_file(remote, &body, false, std::io::stdout())
         }
         PipelineOptions::MergedCi => {
-            let remote = remote::get_cicd(domain, path, config, None)?;
+            // TODO - should propagage cache args
+            let remote = remote::get_cicd(domain, path, config, None, CacheType::File)?;
             let file = std::fs::File::open(".gitlab-ci.yml")?;
             let body = read_ci_file(file)?;
             lint_ci_file(remote, &body, true, std::io::stdout())
@@ -432,8 +434,13 @@ pub fn execute(
             Ok(())
         }
         PipelineOptions::List(cli_args) => {
-            let remote =
-                remote::get_cicd(domain, path, config, Some(&cli_args.get_args.cache_args))?;
+            let remote = remote::get_cicd(
+                domain,
+                path,
+                config,
+                Some(&cli_args.get_args.cache_args),
+                CacheType::File,
+            )?;
             if cli_args.num_pages {
                 return num_cicd_pages(remote, std::io::stdout());
             } else if cli_args.num_resources {
@@ -452,6 +459,7 @@ pub fn execute(
                     path,
                     config,
                     Some(&cli_args.list_args.get_args.cache_args),
+                    CacheType::File,
                 )?;
                 let from_to_args = remote::validate_from_to_page(&cli_args.list_args)?;
                 let body_args = JobListBodyArgs::builder().list_args(from_to_args).build()?;
@@ -471,6 +479,7 @@ pub fn execute(
                     path,
                     config,
                     Some(&cli_args.list_args.get_args.cache_args),
+                    CacheType::File,
                 )?;
                 let from_to_args = remote::validate_from_to_page(&cli_args.list_args)?;
                 let tags = cli_args.tags.clone();
@@ -494,11 +503,12 @@ pub fn execute(
                     path,
                     config,
                     Some(&cli_args.get_args.cache_args),
+                    CacheType::File,
                 )?;
                 get_runner_details(remote, cli_args, std::io::stdout())
             }
             RunnerOptions::Create(cli_args) => {
-                let remote = remote::get_cicd_runner(domain, path, config, None)?;
+                let remote = remote::get_cicd_runner(domain, path, config, None, CacheType::None)?;
                 create_runner(remote, cli_args, std::io::stdout())
             }
         },

--- a/src/cmds/common.rs
+++ b/src/cmds/common.rs
@@ -1,5 +1,6 @@
 /// Common functions and macros that are used by multiple commands
 use crate::config::ConfigProperties;
+use crate::remote::CacheType;
 use crate::Result;
 use crate::{api_traits::MergeRequest, remote::ListRemoteCliArgs};
 use crate::{display, remote};
@@ -253,6 +254,7 @@ pub fn get_user(
         path.to_string(),
         config.clone(),
         Some(&cli_args.get_args.cache_args),
+        CacheType::File,
     )?;
     let user = remote.get()?;
     Ok(user)

--- a/src/cmds/common.rs
+++ b/src/cmds/common.rs
@@ -1,5 +1,5 @@
 /// Common functions and macros that are used by multiple commands
-use crate::config::Config;
+use crate::config::ConfigProperties;
 use crate::Result;
 use crate::{api_traits::MergeRequest, remote::ListRemoteCliArgs};
 use crate::{display, remote};
@@ -245,7 +245,7 @@ list_resource!(list_trending, TrendingProjectURL, String, TrendingCliArgs);
 pub fn get_user(
     domain: &str,
     path: &str,
-    config: &Arc<Config>,
+    config: &Arc<dyn ConfigProperties>,
     cli_args: &ListRemoteCliArgs,
 ) -> Result<Member> {
     let remote = remote::get_auth_user(

--- a/src/cmds/docker.rs
+++ b/src/cmds/docker.rs
@@ -5,7 +5,7 @@ use crate::{
     cli::docker::DockerOptions,
     config::ConfigProperties,
     display::{self, Column, DisplayBody},
-    remote::{self, get_registry, GetRemoteCliArgs, ListBodyArgs, ListRemoteCliArgs},
+    remote::{self, get_registry, CacheType, GetRemoteCliArgs, ListBodyArgs, ListRemoteCliArgs},
     Result,
 };
 
@@ -159,11 +159,18 @@ pub fn execute(
                 path,
                 config,
                 Some(&cli_args.list_args.get_args.cache_args),
+                CacheType::File,
             )?;
             validate_and_list(remote, cli_args, std::io::stdout())
         }
         DockerOptions::Get(cli_args) => {
-            let remote = get_registry(domain, path, config, Some(&cli_args.get_args.cache_args))?;
+            let remote = get_registry(
+                domain,
+                path,
+                config,
+                Some(&cli_args.get_args.cache_args),
+                CacheType::File,
+            )?;
             get_image_metadata(remote, cli_args, std::io::stdout())
         }
     }

--- a/src/cmds/docker.rs
+++ b/src/cmds/docker.rs
@@ -3,7 +3,7 @@ use std::{io::Write, sync::Arc};
 use crate::{
     api_traits::{ContainerRegistry, Timestamp},
     cli::docker::DockerOptions,
-    config::Config,
+    config::ConfigProperties,
     display::{self, Column, DisplayBody},
     remote::{self, get_registry, GetRemoteCliArgs, ListBodyArgs, ListRemoteCliArgs},
     Result,
@@ -148,7 +148,7 @@ impl From<ImageMetadata> for DisplayBody {
 
 pub fn execute(
     options: DockerOptions,
-    config: Arc<Config>,
+    config: Arc<dyn ConfigProperties>,
     domain: String,
     path: String,
 ) -> Result<()> {

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -1,7 +1,7 @@
 use crate::api_traits::{CommentMergeRequest, MergeRequest, RemoteProject, Timestamp};
 use crate::cli::merge_request::MergeRequestOptions;
 use crate::cli::CliArgs;
-use crate::config::{Config, ConfigProperties};
+use crate::config::ConfigProperties;
 use crate::display::{Column, DisplayBody};
 use crate::error::{AddContext, GRError};
 use crate::git::Repo;
@@ -335,7 +335,7 @@ impl From<Comment> for DisplayBody {
 pub fn execute(
     options: MergeRequestOptions,
     global_args: CliArgs,
-    config: Arc<Config>,
+    config: Arc<dyn ConfigProperties>,
     domain: String,
     path: String,
 ) -> Result<()> {
@@ -455,7 +455,7 @@ fn get_filter_user(
     user: &Option<MergeRequestUser>,
     domain: &str,
     path: &str,
-    config: &Arc<Config>,
+    config: &Arc<dyn ConfigProperties>,
     list_args: &ListRemoteCliArgs,
 ) -> Result<Option<Member>> {
     let member = match user {
@@ -470,7 +470,7 @@ fn get_filter_user(
 pub fn list_merge_requests(
     domain: String,
     path: String,
-    config: Arc<Config>,
+    config: Arc<dyn ConfigProperties>,
     cli_args: MergeRequestListCliArgs,
 ) -> Result<()> {
     // Author, assignee and reviewer are mutually exclusive filters checked on
@@ -526,7 +526,7 @@ pub fn list_merge_requests(
 
 fn user_prompt_confirmation(
     mr_body: &MergeRequestBody,
-    config: Arc<impl ConfigProperties>,
+    config: Arc<dyn ConfigProperties>,
     description: String,
     target_branch: &String,
     cli_args: &MergeRequestCliArgs,
@@ -594,7 +594,7 @@ fn user_prompt_confirmation(
 /// Open a merge request.
 fn open(
     remote: Arc<dyn MergeRequest>,
-    config: Arc<impl ConfigProperties>,
+    config: Arc<dyn ConfigProperties>,
     mr_body: MergeRequestBody,
     cli_args: &MergeRequestCliArgs,
 ) -> Result<()> {

--- a/src/cmds/my.rs
+++ b/src/cmds/my.rs
@@ -1,7 +1,11 @@
 use std::{io::Write, sync::Arc};
 
 use crate::{
-    api_traits::RemoteProject, cli::my::MyOptions, config::ConfigProperties, remote, Result,
+    api_traits::RemoteProject,
+    cli::my::MyOptions,
+    config::ConfigProperties,
+    remote::{self, CacheType},
+    Result,
 };
 
 use super::{
@@ -27,6 +31,7 @@ pub fn execute(
                 path,
                 config,
                 Some(&cli_args.list_args.get_args.cache_args),
+                CacheType::File,
             )?;
             let from_to_args = remote::validate_from_to_page(&cli_args.list_args)?;
             let body_args = ProjectListBodyArgs::builder()
@@ -48,6 +53,7 @@ pub fn execute(
                 path,
                 config,
                 Some(&cli_args.list_args.get_args.cache_args),
+                CacheType::File,
             )?;
             if cli_args.list_args.num_pages {
                 return common::num_user_gists(remote, std::io::stdout());

--- a/src/cmds/my.rs
+++ b/src/cmds/my.rs
@@ -1,6 +1,8 @@
 use std::{io::Write, sync::Arc};
 
-use crate::{api_traits::RemoteProject, cli::my::MyOptions, config::Config, remote, Result};
+use crate::{
+    api_traits::RemoteProject, cli::my::MyOptions, config::ConfigProperties, remote, Result,
+};
 
 use super::{
     common::{self, get_user},
@@ -10,7 +12,7 @@ use super::{
 
 pub fn execute(
     options: MyOptions,
-    config: Arc<Config>,
+    config: Arc<dyn ConfigProperties>,
     domain: String,
     path: String,
 ) -> Result<()> {

--- a/src/cmds/project.rs
+++ b/src/cmds/project.rs
@@ -4,7 +4,7 @@ use crate::config::ConfigProperties;
 use crate::display::{self, Column, DisplayBody};
 use crate::error;
 use crate::io::CmdInfo;
-use crate::remote::{self, GetRemoteCliArgs, ListBodyArgs, ListRemoteCliArgs};
+use crate::remote::{self, CacheType, GetRemoteCliArgs, ListBodyArgs, ListRemoteCliArgs};
 use crate::Result;
 use std::io::Write;
 use std::sync::Arc;
@@ -169,8 +169,13 @@ pub fn execute(
 ) -> Result<()> {
     match options {
         ProjectOptions::Info(cli_args) => {
-            let remote =
-                remote::get_project(domain, path, config, Some(&cli_args.get_args.cache_args))?;
+            let remote = remote::get_project(
+                domain,
+                path,
+                config,
+                Some(&cli_args.get_args.cache_args),
+                CacheType::File,
+            )?;
             project_info(remote, std::io::stdout(), cli_args)
         }
     }

--- a/src/cmds/project.rs
+++ b/src/cmds/project.rs
@@ -1,6 +1,6 @@
 use crate::api_traits::{RemoteProject, Timestamp};
 use crate::cli::project::ProjectOptions;
-use crate::config::Config;
+use crate::config::ConfigProperties;
 use crate::display::{self, Column, DisplayBody};
 use crate::error;
 use crate::io::CmdInfo;
@@ -163,7 +163,7 @@ impl ProjectMetadataGetCliArgs {
 
 pub fn execute(
     options: ProjectOptions,
-    config: Arc<Config>,
+    config: Arc<dyn ConfigProperties>,
     domain: String,
     path: String,
 ) -> Result<()> {

--- a/src/cmds/release.rs
+++ b/src/cmds/release.rs
@@ -6,7 +6,7 @@ use crate::cli::release::{ReleaseAssetOptions, ReleaseOptions};
 use crate::cmds::common::num_release_pages;
 use crate::config::ConfigProperties;
 use crate::display::{Column, DisplayBody};
-use crate::remote::{self, ListBodyArgs, ListRemoteCliArgs};
+use crate::remote::{self, CacheType, ListBodyArgs, ListRemoteCliArgs};
 use crate::Result;
 
 use super::common::{
@@ -137,6 +137,7 @@ pub fn execute(
                 path,
                 config,
                 Some(&cli_args.get_args.cache_args),
+                CacheType::File,
             )?;
             if cli_args.num_pages {
                 return num_release_pages(remote, std::io::stdout());
@@ -157,6 +158,7 @@ pub fn execute(
                     path,
                     config,
                     Some(&cli_args.list_args.get_args.cache_args),
+                    CacheType::File,
                 )?;
 
                 let list_args = remote::validate_from_to_page(&cli_args.list_args)?;

--- a/src/cmds/release.rs
+++ b/src/cmds/release.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::api_traits::{Deploy, DeployAsset, Timestamp};
 use crate::cli::release::{ReleaseAssetOptions, ReleaseOptions};
 use crate::cmds::common::num_release_pages;
-use crate::config::Config;
+use crate::config::ConfigProperties;
 use crate::display::{Column, DisplayBody};
 use crate::remote::{self, ListBodyArgs, ListRemoteCliArgs};
 use crate::Result;
@@ -126,7 +126,7 @@ impl Timestamp for ReleaseAssetMetadata {
 
 pub fn execute(
     options: ReleaseOptions,
-    config: Arc<Config>,
+    config: Arc<dyn ConfigProperties>,
     domain: String,
     path: String,
 ) -> Result<()> {

--- a/src/cmds/trending.rs
+++ b/src/cmds/trending.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 use std::sync::Arc;
 
 use crate::api_traits::TrendingProjectURL;
-use crate::config::Config;
+use crate::config::ConfigProperties;
 use crate::display::{Column, DisplayBody};
 use crate::remote::{self, GetRemoteCliArgs};
 use crate::Result;
@@ -42,7 +42,11 @@ impl From<TrendingProject> for DisplayBody {
     }
 }
 
-pub fn execute(cli_args: TrendingCliArgs, config: Arc<Config>, domain: &str) -> Result<()> {
+pub fn execute(
+    cli_args: TrendingCliArgs,
+    config: Arc<dyn ConfigProperties>,
+    domain: &str,
+) -> Result<()> {
     let remote = remote::get_trending(
         domain.to_string(),
         // does not matter in this command. Implementing it for

--- a/src/cmds/trending.rs
+++ b/src/cmds/trending.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::api_traits::TrendingProjectURL;
 use crate::config::ConfigProperties;
 use crate::display::{Column, DisplayBody};
-use crate::remote::{self, GetRemoteCliArgs};
+use crate::remote::{self, CacheType, GetRemoteCliArgs};
 use crate::Result;
 
 use super::common;
@@ -54,6 +54,7 @@ pub fn execute(
         "".to_string(),
         config,
         Some(&cli_args.get_args.cache_args),
+        CacheType::File,
     )?;
     get_urls(remote, cli_args, &mut std::io::stdout())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -357,12 +357,12 @@ mod test {
     #[test]
     fn test_get_api_token() {
         let config_data = r#"
-        gitlab.com.api_token=1234
-        github.com.api_token=4567
-        gitlab.com.cache_location=/home/user/.config/mr_cache
-        github.com.cache_location=/home/user/.config/mr_cache
+        gitlabab.com.api_token=1234
+        githubab.com.api_token=4567
+        gitlabab.com.cache_location=/home/user/.config/mr_cache
+        githubab.com.cache_location=/home/user/.config/mr_cache
         "#;
-        let domain = "gitlab.com";
+        let domain = "gitlabab.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!("1234", config.api_token());
@@ -373,12 +373,12 @@ mod test {
         let config_data = r#"
 
         # api token
-        gitlab.com.api_token=1234
-        github.com.api_token=4567
-        gitlab.com.cache_location=/home/user/.config/mr_cache
-        github.com.cache_location=/home/user/.config/mr_cache
+        gitlababc.com.api_token=1234
+        githubabc.com.api_token=4567
+        gitlababc.com.cache_location=/home/user/.config/mr_cache
+        githubabc.com.cache_location=/home/user/.config/mr_cache
         "#;
-        let domain = "gitlab.com";
+        let domain = "gitlababc.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!("1234", config.api_token());
@@ -388,8 +388,8 @@ mod test {
     fn test_no_api_token_is_err() {
         let config_data = r#"
         # api token
-        gitlab.com.api_token_typo=1234"#;
-        let domain = "gitlab.com";
+        gitlabde.com.api_token_typo=1234"#;
+        let domain = "gitlabde.com";
         let reader = std::io::Cursor::new(config_data);
         assert!(ConfigFile::new(reader, domain).is_err());
     }
@@ -397,15 +397,15 @@ mod test {
     #[test]
     fn test_config_no_data() {
         let config_data = "";
-        let domain = "gitlab.com";
+        let domain = "gitlabdef.com";
         let reader = std::io::Cursor::new(config_data);
         assert!(ConfigFile::new(reader, domain).is_err());
     }
 
     #[test]
     fn test_config_multiple_equals() {
-        let config_data = "gitlab_api_token===1234";
-        let domain = "gitlab.com";
+        let config_data = "gitlabfg_api_token===1234";
+        let domain = "gitlabfg.com";
         let reader = std::io::Cursor::new(config_data);
         assert!(ConfigFile::new(reader, domain).is_err());
     }
@@ -413,10 +413,10 @@ mod test {
     #[test]
     fn test_get_preferred_assignee_username() {
         let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin"#;
-        let domain = "github.com";
+        githubhe.com.api_token=1234
+        githubhe.com.cache_location=/home/user/.config/mr_cache
+        githubhe.com.preferred_assignee_username=jordilin"#;
+        let domain = "githubhe.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!("jordilin", config.preferred_assignee_username());
@@ -425,11 +425,11 @@ mod test {
     #[test]
     fn test_get_merge_request_description_signature() {
         let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin
-        github.com.merge_request_description_signature=- devops team :-)"#;
-        let domain = "github.com";
+        githuble.com.api_token=1234
+        githuble.com.cache_location=/home/user/.config/mr_cache
+        githuble.com.preferred_assignee_username=jordilin
+        githuble.com.merge_request_description_signature=- devops team :-)"#;
+        let domain = "githuble.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(
@@ -441,18 +441,18 @@ mod test {
     #[test]
     fn test_config_cache_api_expirations() {
         let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin
-        github.com.merge_request_description_signature=- devops team :-)
-        github.com.cache_api_merge_request_expiration=2h
-        github.com.cache_api_pipeline_expiration=1h
-        github.com.cache_api_project_expiration=3h
-        github.com.cache_api_container_registry_expiration=4h
-        github.com.cache_api_single_page_expiration=1d
-        github.com.cache_api_release_expiration=5h
-        github.com.cache_api_gist_expiration=1d"#;
-        let domain = "github.com";
+        githubza.com.api_token=1234
+        githubza.com.cache_location=/home/user/.config/mr_cache
+        githubza.com.preferred_assignee_username=jordilin
+        githubza.com.merge_request_description_signature=- devops team :-)
+        githubza.com.cache_api_merge_request_expiration=2h
+        githubza.com.cache_api_pipeline_expiration=1h
+        githubza.com.cache_api_project_expiration=3h
+        githubza.com.cache_api_container_registry_expiration=4h
+        githubza.com.cache_api_single_page_expiration=1d
+        githubza.com.cache_api_release_expiration=5h
+        githubza.com.cache_api_gist_expiration=1d"#;
+        let domain = "githubza.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(
@@ -473,12 +473,12 @@ mod test {
     #[test]
     fn test_config_cache_api_expiration_default() {
         let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin
-        github.com.merge_request_description_signature=- devops team :-)
+        githubme.com.api_token=1234
+        githubme.com.cache_location=/home/user/.config/mr_cache
+        githubme.com.preferred_assignee_username=jordilin
+        githubme.com.merge_request_description_signature=- devops team :-)
         "#;
-        let domain = "github.com";
+        let domain = "githubme.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(
@@ -490,12 +490,12 @@ mod test {
     #[test]
     fn test_config_max_pages_merge_requests() {
         let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin
-        github.com.max_pages_api_merge_request=2
+        githubpo.com.api_token=1234
+        githubpo.com.cache_location=/home/user/.config/mr_cache
+        githubpo.com.preferred_assignee_username=jordilin
+        githubpo.com.max_pages_api_merge_request=2
         "#;
-        let domain = "github.com";
+        let domain = "githubpo.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(2, config.get_max_pages(&ApiOperation::MergeRequest));
@@ -504,11 +504,11 @@ mod test {
     #[test]
     fn test_config_max_pages_default_merge_request() {
         let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin
+        github99.com.api_token=1234
+        github99.com.cache_location=/home/user/.config/mr_cache
+        github99.com.preferred_assignee_username=jordilin
         "#;
-        let domain = "github.com";
+        let domain = "github99.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(
@@ -520,12 +520,12 @@ mod test {
     #[test]
     fn test_config_max_pages_pipeline() {
         let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin
-        github.com.max_pages_api_pipeline=4
+        github00.com.api_token=1234
+        github00.com.cache_location=/home/user/.config/mr_cache
+        github00.com.preferred_assignee_username=jordilin
+        github00.com.max_pages_api_pipeline=4
         "#;
-        let domain = "github.com";
+        let domain = "github00.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(4, config.get_max_pages(&ApiOperation::Pipeline));
@@ -534,10 +534,10 @@ mod test {
     #[test]
     fn test_config_max_pages_default_pipeline() {
         let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin"#;
-        let domain = "github.com";
+        github.11.com.api_token=1234
+        github.11.com.cache_location=/home/user/.config/mr_cache
+        github.11.com.preferred_assignee_username=jordilin"#;
+        let domain = "github.11.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(
@@ -549,12 +549,12 @@ mod test {
     #[test]
     fn test_config_max_pages_project() {
         let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin
-        github.com.max_pages_api_project=6
+        github44.com.api_token=1234
+        github44.com.cache_location=/home/user/.config/mr_cache
+        github44.com.preferred_assignee_username=jordilin
+        github44.com.max_pages_api_project=6
         "#;
-        let domain = "github.com";
+        let domain = "github44.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(6, config.get_max_pages(&ApiOperation::Project));
@@ -563,10 +563,10 @@ mod test {
     #[test]
     fn test_config_max_pages_default_project() {
         let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin"#;
-        let domain = "github.com";
+        github23.com.api_token=1234
+        github23.com.cache_location=/home/user/.config/mr_cache
+        github23.com.preferred_assignee_username=jordilin"#;
+        let domain = "github23.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(
@@ -578,11 +578,11 @@ mod test {
     #[test]
     fn test_get_rate_limit_remaining_threshold() {
         let config_data = r#"
-        gitlab.com.api_token=1234
-        gitlab.com.cache_location=/home/user/.config/mr_cache
-        gitlab.com.rate_limit_remaining_threshold=15
+        gitlab66.com.api_token=1234
+        gitlab66.com.cache_location=/home/user/.config/mr_cache
+        gitlab66.com.rate_limit_remaining_threshold=15
         "#;
-        let domain = "gitlab.com";
+        let domain = "gitlab66.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(15, config.rate_limit_remaining_threshold());
@@ -591,11 +591,11 @@ mod test {
     #[test]
     fn test_get_max_pages_for_container_registry_operations() {
         let config_data = r#"
-        gitlab.com.api_token=1234
-        gitlab.com.cache_location=/home/user/.config/mr_cache
-        gitlab.com.max_pages_api_container_registry=15
+        gitlab77.com.api_token=1234
+        gitlab77.com.cache_location=/home/user/.config/mr_cache
+        gitlab77.com.max_pages_api_container_registry=15
         "#;
-        let domain = "gitlab.com";
+        let domain = "gitlab77.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(15, config.get_max_pages(&ApiOperation::ContainerRegistry));
@@ -604,11 +604,11 @@ mod test {
     #[test]
     fn test_get_max_pages_for_read_releases() {
         let config_data = r#"
-        gitlab.com.api_token=1234
-        gitlab.com.cache_location=/home/user/.config/mr_cache
-        gitlab.com.max_pages_api_release=15
+        gitlabed.com.api_token=1234
+        gitlabed.com.cache_location=/home/user/.config/mr_cache
+        gitlabed.com.max_pages_api_release=15
         "#;
-        let domain = "gitlab.com";
+        let domain = "gitlabed.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(15, config.get_max_pages(&ApiOperation::Release));
@@ -617,11 +617,11 @@ mod test {
     #[test]
     fn test_get_max_pages_for_gists() {
         let config_data = r#"
-        gitlab.com.api_token=1234
-        gitlab.com.cache_location=/home/user/.config/mr_cache
-        gitlab.com.max_pages_api_gist=15
+        gitlabty.com.api_token=1234
+        gitlabty.com.cache_location=/home/user/.config/mr_cache
+        gitlabty.com.max_pages_api_gist=15
         "#;
-        let domain = "gitlab.com";
+        let domain = "gitlabty.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!(15, config.get_max_pages(&ApiOperation::Gist));
@@ -635,43 +635,43 @@ mod test {
     #[test]
     fn test_use_gitlab_com_api_token_envvar() {
         let config_data = r#"
-        gitlab.com.cache_location=/home/user/.config/mr_cache
-        gitlab.com.rate_limit_remaining_threshold=15
+        gitlabfoo.com.cache_location=/home/user/.config/mr_cache
+        gitlabfoo.com.rate_limit_remaining_threshold=15
         "#;
-        let domain = "gitlab.com";
+        let domain = "gitlabfoo.com";
         let reader = std::io::Cursor::new(config_data);
-        std::env::set_var("GITLAB_API_TOKEN", "1234");
+        std::env::set_var("GITLABFOO_API_TOKEN", "1234");
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!("1234", config.api_token());
-        std::env::remove_var("GITLAB_API_TOKEN");
+        std::env::remove_var("GITLABFOO_API_TOKEN");
     }
 
     #[test]
     fn test_use_github_com_api_token_envvar() {
         let config_data = r#"
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.rate_limit_remaining_threshold=15
+        githubabn.com.cache_location=/home/user/.config/mr_cache
+        githubabn.com.rate_limit_remaining_threshold=15
         "#;
-        let domain = "github.com";
+        let domain = "githubabn.com";
         let reader = std::io::Cursor::new(config_data);
-        std::env::set_var("GITHUB_API_TOKEN", "4567");
+        std::env::set_var("GITHUBABN_API_TOKEN", "4567");
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!("4567", config.api_token());
-        std::env::remove_var("GITHUB_API_TOKEN");
+        std::env::remove_var("GITHUBABN_API_TOKEN");
     }
 
     #[test]
     fn test_use_sub_domain_gitlab_token_env_var() {
         let config_data = r#"
-        gitlab.company.com.cache_location=/home/user/.config/mr_cache
-        gitlab.company.com.rate_limit_remaining_threshold=15
+        gitlabhj.company.com.cache_location=/home/user/.config/mr_cache
+        gitlabhj.company.com.rate_limit_remaining_threshold=15
         "#;
-        let domain = "gitlab.company.com";
+        let domain = "gitlabhj.company.com";
         let reader = std::io::Cursor::new(config_data);
-        std::env::set_var("GITLAB_COMPANY_API_TOKEN", "1214");
+        std::env::set_var("GITLABHJ_COMPANY_API_TOKEN", "1214");
         let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
         assert_eq!("1214", config.api_token());
-        std::env::remove_var("GITLAB_COMPANY_API_TOKEN");
+        std::env::remove_var("GITLABHJ_COMPANY_API_TOKEN");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,7 +126,7 @@ impl ConfigFile {
 
         Ok(ConfigFile {
             api_token: api_token.to_string(),
-            cache_location: cache_location,
+            cache_location,
             preferred_assignee_username: preferred_assignee_username.to_string(),
             merge_request_description_signature: merge_request_description_signature.to_string(),
             cache_expirations,

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,7 +62,7 @@ impl ConfigProperties for NoConfig {
 #[derive(Clone, Debug, Default)]
 pub struct ConfigFile {
     api_token: String,
-    cache_location: String,
+    cache_location: Option<String>,
     preferred_assignee_username: String,
     merge_request_description_signature: String,
     // TODO, should be <ApiOperation, Seconds>
@@ -108,12 +108,7 @@ impl ConfigFile {
             })?;
             Ok(token_res.to_string())
         })?;
-        let cache_location = domain_config_data.get("cache_location").ok_or_else(|| {
-            error::gen(format!(
-                "No cache_location found for domain {} in config",
-                domain
-            ))
-        })?;
+        let cache_location = domain_config_data.get("cache_location").cloned();
         let default_assignee_username = "".to_string();
         let preferred_assignee_username = domain_config_data
             .get("preferred_assignee_username")
@@ -131,7 +126,7 @@ impl ConfigFile {
 
         Ok(ConfigFile {
             api_token: api_token.to_string(),
-            cache_location: cache_location.to_string(),
+            cache_location: cache_location,
             preferred_assignee_username: preferred_assignee_username.to_string(),
             merge_request_description_signature: merge_request_description_signature.to_string(),
             cache_expirations,
@@ -288,7 +283,7 @@ impl ConfigProperties for ConfigFile {
     }
 
     fn cache_location(&self) -> Option<&str> {
-        Some(&self.cache_location)
+        self.cache_location.as_deref()
     }
 
     fn preferred_assignee_username(&self) -> &str {

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -37,7 +37,7 @@ pub fn prompt_user_merge_request_info(
     default_title: &str,
     default_description: &str,
     members: &[Member],
-    config: Arc<impl ConfigProperties>,
+    config: Arc<dyn ConfigProperties>,
 ) -> Result<MergeRequestUserInput> {
     let (title, description) = prompt_user_title_description(default_title, default_description);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,8 @@ pub enum GRError {
     HttpTransportError(String),
     #[error("Mermaid parsing error: {0}")]
     MermaidParsingError(String),
+    #[error("Configuration not found")]
+    ConfigurationNotFound,
 }
 
 pub trait AddContext<T, E>: Context<T, E> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,14 @@ pub enum GRError {
     MermaidParsingError(String),
     #[error("Configuration not found")]
     ConfigurationNotFound,
+    #[error("Cache location does not exist: {0}")]
+    CacheLocationDoesNotExist(String),
+    #[error("Cache location is not a directory: {0}")]
+    CacheLocationIsNotADirectory(String),
+    #[error("Cache location is not writeable: {0}")]
+    CacheLocationIsNotWriteable(String),
+    #[error("Cache location write test failed: {0}")]
+    CacheLocationWriteTestFailed(String),
 }
 
 pub trait AddContext<T, E>: Context<T, E> {

--- a/src/github.rs
+++ b/src/github.rs
@@ -21,7 +21,12 @@ pub struct Github<R> {
 }
 
 impl<R> Github<R> {
-    pub fn new(config: impl ConfigProperties, domain: &str, path: &str, runner: Arc<R>) -> Self {
+    pub fn new(
+        config: Arc<dyn ConfigProperties>,
+        domain: &str,
+        path: &str,
+        runner: Arc<R>,
+    ) -> Self {
         let api_token = config.api_token().to_string();
         let domain = domain.to_string();
         let rest_api_basepath = format!("https://api.{}", domain);

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -27,7 +27,12 @@ pub struct Gitlab<R> {
 }
 
 impl<R> Gitlab<R> {
-    pub fn new(config: impl ConfigProperties, domain: &str, path: &str, runner: Arc<R>) -> Self {
+    pub fn new(
+        config: Arc<dyn ConfigProperties>,
+        domain: &str,
+        path: &str,
+        runner: Arc<R>,
+    ) -> Self {
         let api_token = config.api_token().to_string();
         let domain = domain.to_string();
         let encoded_path = encode_path(path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn handle_cli_options(
         }
         CliOptions::Browse(options) => {
             // Use default config for browsing - does not require auth.
-            let config = Arc::new(gr::config::Config::default());
+            let config = Arc::new(gr::config::ConfigFile::default());
             let requirements = vec![
                 CliDomainRequirements::RepoArgs,
                 CliDomainRequirements::CdInLocalRepo,
@@ -137,7 +137,7 @@ fn handle_cli_options(
         }
         CliOptions::Manual => browse::execute(
             BrowseOptions::Manual,
-            Arc::new(gr::config::Config::default()),
+            Arc::new(gr::config::ConfigFile::default()),
             "".to_string(),
             "".to_string(),
         ),

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -370,6 +370,7 @@ macro_rules! get {
                     [<create_remote_ $func_name>](domain, path, config, runner)
                 } else {
                     let file_cache = FileCache::new(config.clone());
+                    file_cache.validate_cache_location()?;
                     let runner = Arc::new(http::Client::new(file_cache, config.clone(), refresh_cache));
                     [<create_remote_ $func_name>](domain, path, config, runner)
                 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -346,6 +346,7 @@ pub enum ListSortMode {
     Desc,
 }
 
+#[derive(Clone, Debug, PartialEq)]
 pub enum CacheType {
     File,
     None,
@@ -363,9 +364,9 @@ macro_rules! get {
                 cache_type: CacheType,
             ) -> Result<Arc<dyn $trait_name + Send + Sync + 'static>> {
                 let refresh_cache = cache_args.map_or(false, |args| args.refresh);
-                let no_cache = cache_args.map_or(false, |args| args.no_cache);
+                let no_cache_args = cache_args.map_or(false, |args| args.no_cache);
 
-                if no_cache || config.cache_location().is_none() {
+                if cache_type == CacheType::None || no_cache_args || config.cache_location().is_none() {
                     let runner = Arc::new(http::Client::new(NoCache, config.clone(), refresh_cache));
                     [<create_remote_ $func_name>](domain, path, config, runner)
                 } else {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -346,6 +346,11 @@ pub enum ListSortMode {
     Desc,
 }
 
+pub enum CacheType {
+    File,
+    None,
+}
+
 use crate::config::ConfigProperties;
 macro_rules! get {
     ($func_name:ident, $trait_name:ident) => {
@@ -355,6 +360,7 @@ macro_rules! get {
                 path: String,
                 config: Arc<dyn ConfigProperties + Send + Sync + 'static>,
                 cache_args: Option<&CacheCliArgs>,
+                cache_type: CacheType,
             ) -> Result<Arc<dyn $trait_name + Send + Sync + 'static>> {
                 let refresh_cache = cache_args.map_or(false, |args| args.refresh);
                 let no_cache = cache_args.map_or(false, |args| args.no_cache);

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -7,7 +7,7 @@ use crate::api_traits::{
     DeployAsset, MergeRequest, RemoteProject, TrendingProjectURL, UserInfo,
 };
 use crate::cache::{filesystem::FileCache, nocache::NoCache};
-use crate::config::Config;
+use crate::config::{ConfigFile, NoConfig};
 use crate::display::Format;
 use crate::error::GRError;
 use crate::github::Github;
@@ -346,18 +346,21 @@ pub enum ListSortMode {
     Desc,
 }
 
+use crate::config::ConfigProperties;
 macro_rules! get {
     ($func_name:ident, $trait_name:ident) => {
         paste::paste! {
             pub fn $func_name(
                 domain: String,
                 path: String,
-                config: Arc<Config>,
+                config: Arc<dyn ConfigProperties + Send + Sync + 'static>,
                 cache_args: Option<&CacheCliArgs>,
             ) -> Result<Arc<dyn $trait_name + Send + Sync + 'static>> {
                 let refresh_cache = cache_args.map_or(false, |args| args.refresh);
                 let no_cache = cache_args.map_or(false, |args| args.no_cache);
-
+                // Also if config.get_cache_location is "" then assume NoCache
+                // or better config.get_type, Virtual vs File. A VirtualConfig
+                // has no cache specification.
                 if no_cache {
                     let runner = Arc::new(http::Client::new(NoCache, config.clone(), refresh_cache));
                     [<create_remote_ $func_name>](domain, path, config, runner)
@@ -371,7 +374,7 @@ macro_rules! get {
             fn [<create_remote_ $func_name>]<R>(
                 domain: String,
                 path: String,
-                config: Arc<Config>,
+                config: Arc<dyn ConfigProperties>,
                 runner: Arc<R>,
             ) -> Result<Arc<dyn $trait_name + Send + Sync + 'static>>
             where
@@ -505,10 +508,17 @@ pub fn get_domain_path<R: TaskRunner<Response = Response>>(
     .into())
 }
 
-pub fn read_config(config_file: &Path, domain: &str) -> Result<Arc<Config>> {
-    let f = File::open(config_file)?;
-    let config = Config::new(f, domain)?;
-    Ok(Arc::new(config))
+pub fn read_config(config_file: &Path, domain: &str) -> Result<Arc<dyn ConfigProperties>> {
+    match File::open(config_file) {
+        Ok(f) => {
+            let config = ConfigFile::new(f, domain)?;
+            Ok(Arc::new(config))
+        }
+        Err(_) => {
+            let config = NoConfig::new(domain)?;
+            Ok(Arc::new(config))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -358,10 +358,8 @@ macro_rules! get {
             ) -> Result<Arc<dyn $trait_name + Send + Sync + 'static>> {
                 let refresh_cache = cache_args.map_or(false, |args| args.refresh);
                 let no_cache = cache_args.map_or(false, |args| args.no_cache);
-                // Also if config.get_cache_location is "" then assume NoCache
-                // or better config.get_type, Virtual vs File. A VirtualConfig
-                // has no cache specification.
-                if no_cache {
+
+                if no_cache || config.cache_location().is_none() {
                     let runner = Arc::new(http::Client::new(NoCache, config.clone(), refresh_cache));
                     [<create_remote_ $func_name>](domain, path, config, runner)
                 } else {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -14,7 +14,7 @@ use crate::github::Github;
 use crate::gitlab::Gitlab;
 use crate::io::{CmdInfo, HttpRunner, Response, TaskRunner};
 use crate::time::Milliseconds;
-use crate::{cli, error, http};
+use crate::{cli, error, http, log_debug, log_info};
 use crate::{git, Result};
 use std::sync::Arc;
 
@@ -366,10 +366,16 @@ macro_rules! get {
                 let refresh_cache = cache_args.map_or(false, |args| args.refresh);
                 let no_cache_args = cache_args.map_or(false, |args| args.no_cache);
 
+                log_debug!("cache_type: {:?}", cache_type);
+                log_debug!("no_cache_args: {:?}", no_cache_args);
+                log_debug!("cache location: {:?}", config.cache_location());
+
                 if cache_type == CacheType::None || no_cache_args || config.cache_location().is_none() {
+                    log_info!("No cache used for {}", stringify!($func_name));
                     let runner = Arc::new(http::Client::new(NoCache, config.clone(), refresh_cache));
                     [<create_remote_ $func_name>](domain, path, config, runner)
                 } else {
+                    log_info!("File cache used for {}", stringify!($func_name));
                     let file_cache = FileCache::new(config.clone());
                     file_cache.validate_cache_location()?;
                     let runner = Arc::new(http::Client::new(file_cache, config.clone(), refresh_cache));

--- a/src/test.rs
+++ b/src/test.rs
@@ -196,16 +196,16 @@ pub mod utils {
         fn api_token(&self) -> &str {
             "1234"
         }
-        fn cache_location(&self) -> &str {
-            ""
+        fn cache_location(&self) -> Option<&str> {
+            Some("")
         }
         fn get_max_pages(&self, _api_operation: &ApiOperation) -> u32 {
             self.max_pages
         }
     }
 
-    pub fn config() -> impl ConfigProperties {
-        ConfigMock::default()
+    pub fn config() -> Arc<dyn ConfigProperties> {
+        Arc::new(ConfigMock::default())
     }
 
     impl Default for ConfigMock {
@@ -220,8 +220,8 @@ pub mod utils {
         fn api_token(&self) -> &str {
             "1234"
         }
-        fn cache_location(&self) -> &str {
-            ""
+        fn cache_location(&self) -> Option<&str> {
+            Some("")
         }
         fn get_max_pages(&self, _api_operation: &ApiOperation) -> u32 {
             self.as_ref().max_pages

--- a/tests/fs_cache_test.rs
+++ b/tests/fs_cache_test.rs
@@ -1,5 +1,5 @@
-use std::fs;
 use std::path::PathBuf;
+use std::{fs, sync::Arc};
 use tempfile::TempDir;
 
 use gr::{
@@ -19,8 +19,8 @@ impl ConfigProperties for TestConfig {
         "test_token"
     }
 
-    fn cache_location(&self) -> &str {
-        self.cache_dir.to_str().unwrap()
+    fn cache_location(&self) -> Option<&str> {
+        Some(self.cache_dir.to_str().unwrap())
     }
 
     fn get_cache_expiration(&self, _: &ApiOperation) -> &str {
@@ -36,7 +36,7 @@ fn test_file_cache_fresh() {
         cache_dir: temp_dir.path().to_path_buf(),
     };
 
-    let file_cache = FileCache::new(config);
+    let file_cache = FileCache::new(Arc::new(config));
 
     let resource = Resource::new("https://api.example.com/test", Some(ApiOperation::Project));
 
@@ -85,7 +85,7 @@ fn test_file_cache_stale_user_expired_no_cache() {
         cache_dir: temp_dir.path().to_path_buf(),
     };
 
-    let file_cache = FileCache::new(config);
+    let file_cache = FileCache::new(Arc::new(config));
 
     let resource = Resource::new("https://api.example.com/test", Some(ApiOperation::Project));
 
@@ -131,7 +131,7 @@ fn test_file_cache_fresh_user_expired_but_under_max_age() {
         cache_dir: temp_dir.path().to_path_buf(),
     };
 
-    let file_cache = FileCache::new(config);
+    let file_cache = FileCache::new(Arc::new(config));
 
     let resource = Resource::new("https://api.example.com/test", Some(ApiOperation::Project));
 
@@ -180,7 +180,7 @@ fn test_cache_stale_both_user_expired_and_max_aged_expired() {
         cache_dir: temp_dir.path().to_path_buf(),
     };
 
-    let file_cache = FileCache::new(config);
+    let file_cache = FileCache::new(Arc::new(config));
 
     let resource = Resource::new("https://api.example.com/test", Some(ApiOperation::Project));
 
@@ -222,7 +222,7 @@ fn test_cache_update_refreshes_cache() {
         cache_dir: temp_dir.path().to_path_buf(),
     };
 
-    let file_cache = FileCache::new(config);
+    let file_cache = FileCache::new(Arc::new(config));
 
     let resource = Resource::new("https://api.example.com/test", Some(ApiOperation::Project));
 

--- a/tests/fs_cache_test.rs
+++ b/tests/fs_cache_test.rs
@@ -1,3 +1,4 @@
+use gr::error::GRError;
 use std::path::PathBuf;
 use std::{fs, sync::Arc};
 use tempfile::TempDir;
@@ -259,5 +260,107 @@ fn test_cache_update_refreshes_cache() {
             assert_eq!(cached_response.body, "Test response body");
         }
         _ => panic!("Expected a fresh cache state"),
+    }
+}
+
+#[test]
+fn test_validate_cache_location_success() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = TestConfig {
+        cache_dir: temp_dir.path().to_path_buf(),
+    };
+
+    let file_cache = FileCache::new(Arc::new(config));
+    assert!(file_cache.validate_cache_location().is_ok());
+}
+
+#[test]
+fn test_validate_cache_location_not_found() {
+    let config = TestConfig {
+        cache_dir: PathBuf::from("/non/existent/directory"),
+    };
+
+    let file_cache = FileCache::new(Arc::new(config));
+    let err = file_cache.validate_cache_location().unwrap_err();
+    match err.downcast_ref::<GRError>() {
+        Some(GRError::CacheLocationDoesNotExist(msg)) => {
+            assert!(msg.contains("/non/existent/directory"));
+        }
+        _ => panic!("Expected CacheLocationDoesNotExist error"),
+    }
+}
+
+#[test]
+fn test_validate_cache_location_not_a_directory() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_file = temp_dir.path().join("not_a_directory");
+    fs::write(&temp_file, "").unwrap();
+
+    let config = TestConfig {
+        cache_dir: temp_file.clone(),
+    };
+
+    let file_cache = FileCache::new(Arc::new(config));
+    let err = file_cache.validate_cache_location().unwrap_err();
+    match err.downcast_ref::<GRError>() {
+        Some(GRError::CacheLocationIsNotADirectory(msg)) => {
+            assert!(msg.contains(temp_file.to_string_lossy().as_ref()));
+        }
+        _ => panic!("Expected CacheLocationIsNotADirectory error"),
+    }
+}
+
+#[test]
+fn test_validate_cache_location_not_writable() {
+    let temp_dir = TempDir::new().unwrap();
+    let cache_dir = temp_dir.path().to_path_buf();
+
+    // Make the directory read-only
+    let mut perms = fs::metadata(&cache_dir).unwrap().permissions();
+    perms.set_readonly(true);
+    fs::set_permissions(&cache_dir, perms).unwrap();
+
+    let config = TestConfig {
+        cache_dir: cache_dir.clone(),
+    };
+
+    let file_cache = FileCache::new(Arc::new(config));
+    let err = file_cache.validate_cache_location().unwrap_err();
+    match err.downcast_ref::<GRError>() {
+        Some(GRError::CacheLocationIsNotWriteable(msg)) => {
+            assert!(msg.contains(cache_dir.to_string_lossy().as_ref()));
+        }
+        _ => panic!("Expected CacheLocationIsNotWriteable error"),
+    }
+
+    // Restore permissions for cleanup
+    let mut perms = fs::metadata(&cache_dir).unwrap().permissions();
+    perms.set_readonly(false);
+    fs::set_permissions(&cache_dir, perms).unwrap();
+}
+
+#[test]
+fn test_validate_cache_location_config_not_found() {
+    struct NoConfig;
+
+    impl ConfigProperties for NoConfig {
+        fn api_token(&self) -> &str {
+            "test_token"
+        }
+
+        fn cache_location(&self) -> Option<&str> {
+            None
+        }
+
+        fn get_cache_expiration(&self, _: &ApiOperation) -> &str {
+            "3600s"
+        }
+    }
+
+    let file_cache = FileCache::new(Arc::new(NoConfig));
+    let err = file_cache.validate_cache_location().unwrap_err();
+    match err.downcast_ref::<GRError>() {
+        Some(GRError::ConfigurationNotFound) => {}
+        _ => panic!("Expected ConfigurationNotFound error"),
     }
 }

--- a/tests/read_config_test.rs
+++ b/tests/read_config_test.rs
@@ -46,19 +46,21 @@ fn test_read_config_file_not_found_with_token_env_var_is_ok() {
 #[test]
 fn test_read_config_empty_file() {
     let temp_file = create_temp_config_file("");
-    let result = read_config(temp_file.path(), "github.com");
+    let result = read_config(temp_file.path(), "githubmo.com");
     assert!(result.is_err());
 }
 
 #[test]
 fn test_read_config_invalid_data() {
     let config_content = r#"
-    github.com.api_token=1234
-    github.com.cache_location
+    githubjd.com.api_token=1234
+    # Missing cache_location - This is still a valid config where key has no value
+    githubjd.com.cache_location
     "#;
     let temp_file = create_temp_config_file(config_content);
-    let result = read_config(temp_file.path(), "github.com");
-    assert!(result.is_err());
+    let config = read_config(temp_file.path(), "githubjd.com").unwrap();
+    assert_eq!(config.api_token(), "1234");
+    assert!(config.cache_location().is_none());
 }
 
 #[test]

--- a/tests/read_config_test.rs
+++ b/tests/read_config_test.rs
@@ -1,0 +1,73 @@
+use gr::remote::read_config;
+use std::io::Write;
+use std::path::Path;
+use tempfile::NamedTempFile;
+
+fn create_temp_config_file(content: &str) -> NamedTempFile {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    write!(temp_file, "{}", content).unwrap();
+    temp_file.flush().unwrap();
+    temp_file
+}
+
+#[test]
+fn test_no_config_auth_env_and_no_cache_flag_ok() {}
+
+#[test]
+fn test_read_config_valid() {
+    let config_content = r#"
+    github.com.api_token=1234
+    github.com.cache_location=/tmp/cache
+    gitlab.com.api_token=5678
+    gitlab.com.cache_location=/tmp/cache2
+    "#;
+    let temp_file = create_temp_config_file(config_content);
+    let result = read_config(temp_file.path(), "github.com");
+    assert!(result.is_ok());
+    let config = result.unwrap();
+    assert_eq!(config.api_token(), "1234");
+    assert_eq!(config.cache_location().unwrap(), "/tmp/cache");
+}
+
+#[test]
+fn test_read_config_file_not_found_and_no_token_env_var_is_error() {
+    let result = read_config(Path::new("/non/existent/path.txt"), "github.com");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_read_config_file_not_found_with_token_env_var_is_ok() {
+    std::env::set_var("INTEGRATIONTEST_API_TOKEN", "123");
+    let config_res = read_config(Path::new("/non/existent/path.txt"), "integrationtest.com");
+    assert!(config_res.is_ok());
+    std::env::remove_var("INTEGRATIONTEST_API_TOKEN");
+}
+
+#[test]
+fn test_read_config_empty_file() {
+    let temp_file = create_temp_config_file("");
+    let result = read_config(temp_file.path(), "github.com");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_read_config_invalid_data() {
+    let config_content = r#"
+    github.com.api_token=1234
+    github.com.cache_location
+    "#;
+    let temp_file = create_temp_config_file(config_content);
+    let result = read_config(temp_file.path(), "github.com");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_read_config_unknown_domain() {
+    let config_content = r#"
+    github.com.api_token=1234
+    github.com.cache_location=/tmp/cache
+    "#;
+    let temp_file = create_temp_config_file(config_content);
+    let result = read_config(temp_file.path(), "gitlab.com");
+    assert!(result.is_err());
+}

--- a/tests/read_config_test.rs
+++ b/tests/read_config_test.rs
@@ -11,18 +11,15 @@ fn create_temp_config_file(content: &str) -> NamedTempFile {
 }
 
 #[test]
-fn test_no_config_auth_env_and_no_cache_flag_ok() {}
-
-#[test]
 fn test_read_config_valid() {
     let config_content = r#"
-    github.com.api_token=1234
-    github.com.cache_location=/tmp/cache
-    gitlab.com.api_token=5678
-    gitlab.com.cache_location=/tmp/cache2
+    github.test.com.api_token=1234
+    github.test.com.cache_location=/tmp/cache
+    gitlab.test.com.api_token=5678
+    gitlab.test.com.cache_location=/tmp/cache2
     "#;
     let temp_file = create_temp_config_file(config_content);
-    let result = read_config(temp_file.path(), "github.com");
+    let result = read_config(temp_file.path(), "github.test.com");
     assert!(result.is_ok());
     let config = result.unwrap();
     assert_eq!(config.api_token(), "1234");
@@ -31,7 +28,10 @@ fn test_read_config_valid() {
 
 #[test]
 fn test_read_config_file_not_found_and_no_token_env_var_is_error() {
-    let result = read_config(Path::new("/non/existent/path.txt"), "github.com");
+    let result = read_config(
+        Path::new("/non/existent/path.txt"),
+        "github.integrationtest.com",
+    );
     assert!(result.is_err());
 }
 


### PR DESCRIPTION
* Allow gitar to operate without configuration. This will allow a user to set
  it up for one off operations such as in a CI/CD job as long as an environment
  AUTH TOKEN is provided.
* Allow gitar to also operate without a caching layer.
