### PR TITLE
Implement get repository tags

### DIFF
--- a/contracts/github/list_tags.json
+++ b/contracts/github/list_tags.json
@@ -1,0 +1,12 @@
+[
+    {
+        "name": "v0.1",
+        "commit": {
+            "sha": "c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc",
+            "url": "https://api.github.com/repos/octocat/Hello-World/commits/c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc"
+        },
+        "zipball_url": "https://github.com/octocat/Hello-World/zipball/v0.1",
+        "tarball_url": "https://github.com/octocat/Hello-World/tarball/v0.1",
+        "node_id": "MDQ6VXNlcjE="
+    }
+]

--- a/contracts/gitlab/list_tags.json
+++ b/contracts/gitlab/list_tags.json
@@ -1,0 +1,29 @@
+[
+    {
+        "commit": {
+            "id": "2695effb5807a22ff3d138d593fd856244e155e7",
+            "short_id": "2695effb",
+            "title": "Initial commit",
+            "created_at": "2017-07-26T11:08:53.000+02:00",
+            "parent_ids": [
+                "2a4b78934375d7f53875269ffd4f45fd83a84ebe"
+            ],
+            "message": "Initial commit",
+            "author_name": "John Smith",
+            "author_email": "john@example.com",
+            "authored_date": "2012-05-28T04:42:42-07:00",
+            "committer_name": "Jack Smith",
+            "committer_email": "jack@example.com",
+            "committed_date": "2012-05-28T04:42:42-07:00"
+        },
+        "release": {
+            "tag_name": "1.0.0",
+            "description": "Amazing release. Wow"
+        },
+        "name": "v1.0.0",
+        "target": "2695effb5807a22ff3d138d593fd856244e155e7",
+        "message": null,
+        "protected": true,
+        "created_at": "2017-07-26T11:08:53.000+02:00"
+    }
+]

--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -178,6 +178,7 @@ pub enum ApiOperation {
     SinglePage,
     // Gists
     Gist,
+    RepositoryTag,
 }
 
 impl Display for ApiOperation {
@@ -190,6 +191,7 @@ impl Display for ApiOperation {
             ApiOperation::Release => write!(f, "release"),
             ApiOperation::SinglePage => write!(f, "single_page"),
             ApiOperation::Gist => write!(f, "gist"),
+            ApiOperation::RepositoryTag => write!(f, "repository_tag"),
         }
     }
 }

--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -14,7 +14,7 @@ use crate::{
             Comment, CommentMergeRequestBodyArgs, CommentMergeRequestListBodyArgs,
             MergeRequestBodyArgs, MergeRequestListBodyArgs, MergeRequestResponse,
         },
-        project::{Member, Project, ProjectListBodyArgs},
+        project::{Member, Project, ProjectListBodyArgs, Tag},
         release::{Release, ReleaseAssetListBodyArgs, ReleaseAssetMetadata, ReleaseBodyArgs},
         trending::TrendingProject,
     },
@@ -47,6 +47,10 @@ pub trait RemoteProject {
     fn list(&self, args: ProjectListBodyArgs) -> Result<Vec<Project>>;
     fn num_pages(&self, args: ProjectListBodyArgs) -> Result<Option<u32>>;
     fn num_resources(&self, args: ProjectListBodyArgs) -> Result<Option<NumberDeltaErr>>;
+}
+
+pub trait RemoteTag: RemoteProject {
+    fn list(&self, args: ProjectListBodyArgs) -> Result<Vec<Tag>>;
 }
 
 pub trait Cicd {

--- a/src/cmds/project.rs
+++ b/src/cmds/project.rs
@@ -125,6 +125,8 @@ pub struct ProjectListCliArgs {
     pub list_args: ListRemoteCliArgs,
     #[builder(default)]
     pub stars: bool,
+    #[builder(default)]
+    pub tags: bool,
 }
 
 impl ProjectListCliArgs {
@@ -178,6 +180,7 @@ pub fn execute(
             )?;
             project_info(remote, std::io::stdout(), cli_args)
         }
+        _ => todo!(),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,7 +98,7 @@ impl ConfigFile {
         // GITLAB_API_TOKEN. If the domain is gitlab.<company>.com, the env var
         // to be set is GITLAB_<COMPANY>_API_TOKEN.
 
-        // Remove top level domain, if any (e.g. gitlab.com -> gitlab)
+        // TODO: inject env_token as a function so we can control it in tests
         let api_token = env_token(domain).or_else(|_| -> Result<String> {
             let token_res = domain_config_data.get("api_token").ok_or_else(|| {
                 error::gen(format!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -179,6 +179,13 @@ impl ConfigFile {
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(REST_API_MAX_PAGES),
         );
+        max_pages.insert(
+            ApiOperation::RepositoryTag,
+            domain_config_data
+                .get("max_pages_api_repository_tags")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(REST_API_MAX_PAGES),
+        );
         max_pages
     }
 
@@ -232,6 +239,13 @@ impl ConfigFile {
             ApiOperation::Gist,
             domain_config_data
                 .get("cache_api_gist_expiration")
+                .unwrap_or(&"0s".to_string())
+                .to_string(),
+        );
+        cache_expirations.insert(
+            ApiOperation::RepositoryTag,
+            domain_config_data
+                .get("cache_api_repository_tags_expiration")
                 .unwrap_or(&"0s".to_string())
                 .to_string(),
         );
@@ -706,5 +720,72 @@ mod test {
             },
             _ => panic!("Expected error"),
         }
+    }
+
+    #[test]
+    fn test_config_cache_api_expiration_for_repository_tags() {
+        let config_data = r#"
+        githubzab.com.api_token=1234
+        githubzab.com.cache_location=/home/user/.config/mr_cache
+        githubzab.com.preferred_assignee_username=jordilin
+        githubzab.com.merge_request_description_signature=- devops team :-)
+        githubzab.com.cache_api_repository_tags_expiration=2h
+        "#;
+        let domain = "githubzab.com";
+        let reader = std::io::Cursor::new(config_data);
+        let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
+        assert_eq!(
+            "2h",
+            config.get_cache_expiration(&ApiOperation::RepositoryTag)
+        );
+    }
+
+    #[test]
+    fn test_cache_expiration_for_repository_tags_is_zero_if_not_provided() {
+        let config_data = r#"
+        githubzab.com.api_token=1234
+        githubzab.com.cache_location=/home/user/.config/mr_cache
+        githubzab.com.preferred_assignee_username=jordilin
+        githubzab.com.merge_request_description_signature=- devops team :-)
+        "#;
+        let domain = "githubzab.com";
+        let reader = std::io::Cursor::new(config_data);
+        let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
+        assert_eq!(
+            "0s",
+            config.get_cache_expiration(&ApiOperation::RepositoryTag)
+        );
+    }
+
+    #[test]
+    fn test_get_max_pages_for_repository_tags() {
+        let config_data = r#"
+        githubzab.com.api_token=1234
+        githubzab.com.cache_location=/home/user/.config/mr_cache
+        githubzab.com.preferred_assignee_username=jordilin
+        githubzab.com.merge_request_description_signature=- devops team :-)
+        githubzab.com.max_pages_api_repository_tags=15
+        "#;
+        let domain = "githubzab.com";
+        let reader = std::io::Cursor::new(config_data);
+        let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
+        assert_eq!(15, config.get_max_pages(&ApiOperation::RepositoryTag));
+    }
+
+    #[test]
+    fn test_get_max_pages_repository_tags_default_if_none_provided() {
+        let config_data = r#"
+        githubzab.com.api_token=1234
+        githubzab.com.cache_location=/home/user/.config/mr_cache
+        githubzab.com.preferred_assignee_username=jordilin
+        githubzab.com.merge_request_description_signature=- devops team :-)
+        "#;
+        let domain = "githubzab.com";
+        let reader = std::io::Cursor::new(config_data);
+        let config = Arc::new(ConfigFile::new(reader, domain).unwrap());
+        assert_eq!(
+            REST_API_MAX_PAGES,
+            config.get_max_pages(&ApiOperation::RepositoryTag)
+        );
     }
 }

--- a/src/github/project.rs
+++ b/src/github/project.rs
@@ -1,7 +1,7 @@
 use crate::{
-    api_traits::{ApiOperation, RemoteProject},
+    api_traits::{ApiOperation, RemoteProject, RemoteTag},
     cli::browse::BrowseOptions,
-    cmds::project::{Member, Project, ProjectListBodyArgs},
+    cmds::project::{Member, Project, ProjectListBodyArgs, Tag},
     error::GRError,
     http::Method::GET,
     io::{CmdInfo, HttpRunner, Response},
@@ -108,6 +108,12 @@ impl<R: HttpRunner<Response = Response>> RemoteProject for Github<R> {
             self.request_headers(),
             ApiOperation::Project,
         )
+    }
+}
+
+impl<R: HttpRunner<Response = Response>> RemoteTag for Github<R> {
+    fn list(&self, _args: ProjectListBodyArgs) -> Result<Vec<Tag>> {
+        todo!()
     }
 }
 

--- a/src/github/project.rs
+++ b/src/github/project.rs
@@ -112,27 +112,68 @@ impl<R: HttpRunner<Response = Response>> RemoteProject for Github<R> {
 }
 
 impl<R: HttpRunner<Response = Response>> RemoteTag for Github<R> {
-    fn list(&self, _args: ProjectListBodyArgs) -> Result<Vec<Tag>> {
-        todo!()
+    // https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
+    fn list(&self, args: ProjectListBodyArgs) -> Result<Vec<Tag>> {
+        let url = self.list_project_url(&args, false);
+        let tags = query::github_list_repo_tags(
+            &self.runner,
+            &url,
+            args.from_to_page,
+            self.request_headers(),
+            None,
+            ApiOperation::RepositoryTag,
+        )?;
+        Ok(tags)
+    }
+}
+
+pub struct GithubRepositoryTagFields {
+    tags: Tag,
+}
+
+impl From<&serde_json::Value> for GithubRepositoryTagFields {
+    fn from(tag_data: &serde_json::Value) -> Self {
+        GithubRepositoryTagFields {
+            tags: Tag::builder()
+                .name(tag_data["name"].as_str().unwrap().to_string())
+                .sha(tag_data["commit"]["sha"].as_str().unwrap().to_string())
+                // Github response does not provide a created_at field, so set
+                // it up to UNIX epoch.
+                .created_at("1970-01-01T00:00:00Z".to_string())
+                .build()
+                .unwrap(),
+        }
+    }
+}
+
+impl From<GithubRepositoryTagFields> for Tag {
+    fn from(fields: GithubRepositoryTagFields) -> Self {
+        fields.tags
     }
 }
 
 impl<R> Github<R> {
     fn list_project_url(&self, args: &ProjectListBodyArgs, num_pages: bool) -> String {
-        let url = if args.stars {
-            format!("{}/user/starred", self.rest_api_basepath)
+        let mut url = if args.tags {
+            URLQueryParamBuilder::new(&format!(
+                "{}/repos/{}/tags",
+                self.rest_api_basepath, self.path
+            ))
+        } else if args.stars {
+            URLQueryParamBuilder::new(&format!("{}/user/starred", self.rest_api_basepath))
         } else {
             let username = args.user.as_ref().unwrap().clone().username;
             // TODO - not needed - just /user/repos would do
             // See: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repositories-for-the-authenticated-user
-            format!("{}/users/{}/repos", self.rest_api_basepath, username)
+            URLQueryParamBuilder::new(&format!(
+                "{}/users/{}/repos",
+                self.rest_api_basepath, username
+            ))
         };
         if num_pages {
-            return URLQueryParamBuilder::new(&url)
-                .add_param("page", "1")
-                .build();
+            return url.add_param("page", "1").build();
         }
-        url
+        url.build()
     }
 }
 
@@ -366,6 +407,53 @@ mod test {
         assert_eq!(
             "https://github.com/jordilin/githapi/actions/runs/9527070386",
             url
+        );
+    }
+
+    #[test]
+    fn test_list_project_tags() {
+        let contracts =
+            ResponseContracts::new(ContractType::Github).add_contract(200, "list_tags.json", None);
+        let (client, github) = setup_client!(contracts, default_github(), dyn RemoteTag);
+        let body_args = ProjectListBodyArgs::builder()
+            .user(None)
+            .from_to_page(None)
+            .tags(true)
+            .build()
+            .unwrap();
+        let tags = RemoteTag::list(&*github, body_args).unwrap();
+        assert_eq!(1, tags.len());
+        assert_eq!(
+            "https://api.github.com/repos/jordilin/githapi/tags",
+            *client.url()
+        );
+        assert_eq!(
+            Some(ApiOperation::RepositoryTag),
+            *client.api_operation.borrow()
+        );
+    }
+
+    #[test]
+    fn test_get_project_tags_num_pages() {
+        let link_header = "<https://api.github.com/repos/jordilin/githapi/tags?page=2>; rel=\"next\", <https://api.github.com/repos/jordilin/githapi/tags?page=2>; rel=\"last\"";
+        let mut headers = Headers::new();
+        headers.set("link", link_header);
+        let contracts = ResponseContracts::new(ContractType::Github).add_body::<String>(
+            200,
+            None,
+            Some(headers),
+        );
+        let (client, github) = setup_client!(contracts, default_github(), dyn RemoteTag);
+        let body_args = ProjectListBodyArgs::builder()
+            .user(None)
+            .from_to_page(None)
+            .tags(true)
+            .build()
+            .unwrap();
+        github.num_pages(body_args).unwrap();
+        assert_eq!(
+            "https://api.github.com/repos/jordilin/githapi/tags?page=1",
+            *client.url()
         );
     }
 }

--- a/src/gitlab/project.rs
+++ b/src/gitlab/project.rs
@@ -1,6 +1,6 @@
-use crate::api_traits::{ApiOperation, RemoteProject};
+use crate::api_traits::{ApiOperation, RemoteProject, RemoteTag};
 use crate::cli::browse::BrowseOptions;
-use crate::cmds::project::{Member, Project, ProjectListBodyArgs};
+use crate::cmds::project::{Member, Project, ProjectListBodyArgs, Tag};
 use crate::error::GRError;
 use crate::gitlab::encode_path;
 use crate::http::{self};
@@ -90,6 +90,12 @@ impl<R: HttpRunner<Response = Response>> RemoteProject for Gitlab<R> {
     ) -> Result<Option<crate::api_traits::NumberDeltaErr>> {
         let url = self.list_project_url(&args, true);
         query::num_resources(&self.runner, &url, self.headers(), ApiOperation::Project)
+    }
+}
+
+impl<R: HttpRunner<Response = Response>> RemoteTag for Gitlab<R> {
+    fn list(&self, _args: ProjectListBodyArgs) -> Result<Vec<Tag>> {
+        todo!()
     }
 }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -31,6 +31,8 @@ const CONFIG_TEMPLATE: &str = r#"
 <DOMAIN>.cache_api_single_page_expiration=1d
 # Expire your user gists in 1 day
 <DOMAIN>.cache_api_gist_expiration=1d
+# Expire repository tags immediately
+<DOMAIN>.cache_api_repository_tags_expiration=0s
 
 ## Max pages configuration
 
@@ -46,6 +48,8 @@ const CONFIG_TEMPLATE: &str = r#"
 <DOMAIN>.max_pages_api_release=10
 # Get up to 5 pages of your gists
 <DOMAIN>.max_pages_api_gist=5
+# Get up to 10 pages of tags when listing
+<DOMAIN>.max_pages_api_repository_tags=10
 
 # Rate limit remaining threshold. Threshold by which the tool will stop
 # processing requests. Defaults to 10 if not provided. The remote has a counter

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use crate::api_traits::{
     Cicd, CicdJob, CicdRunner, CodeGist, CommentMergeRequest, ContainerRegistry, Deploy,
-    DeployAsset, MergeRequest, RemoteProject, TrendingProjectURL, UserInfo,
+    DeployAsset, MergeRequest, RemoteProject, RemoteTag, TrendingProjectURL, UserInfo,
 };
 use crate::cache::{filesystem::FileCache, nocache::NoCache};
 use crate::config::{ConfigFile, NoConfig};
@@ -411,6 +411,7 @@ macro_rules! get {
 get!(get_mr, MergeRequest);
 get!(get_cicd, Cicd);
 get!(get_project, RemoteProject);
+get!(get_tag, RemoteTag);
 get!(get_registry, ContainerRegistry);
 get!(get_deploy, Deploy);
 get!(get_deploy_asset, DeployAsset);

--- a/src/remote/query.rs
+++ b/src/remote/query.rs
@@ -11,7 +11,7 @@ use crate::{
         docker::{ImageMetadata, RegistryRepository, RepositoryTag},
         gist::Gist,
         merge_request::{Comment, MergeRequestResponse},
-        project::{Member, Project},
+        project::{Member, Project, Tag},
         release::{Release, ReleaseAssetMetadata},
     },
     display, error,
@@ -19,7 +19,7 @@ use crate::{
         cicd::GithubPipelineFields,
         gist::GithubGistFields,
         merge_request::{GithubMergeRequestCommentFields, GithubMergeRequestFields},
-        project::{GithubMemberFields, GithubProjectFields},
+        project::{GithubMemberFields, GithubProjectFields, GithubRepositoryTagFields},
         release::{GithubReleaseAssetFields, GithubReleaseFields},
         user::GithubUserFields,
     },
@@ -366,6 +366,8 @@ paged!(
 );
 
 paged!(github_list_user_gists, GithubGistFields, Gist);
+
+paged!(github_list_repo_tags, GithubRepositoryTagFields, Tag);
 
 // Single HTTP requests
 

--- a/src/remote/query.rs
+++ b/src/remote/query.rs
@@ -32,7 +32,7 @@ use crate::{
             GitlabImageMetadataFields, GitlabRegistryRepositoryFields, GitlabRepositoryTagFields,
         },
         merge_request::{GitlabMergeRequestCommentFields, GitlabMergeRequestFields},
-        project::{GitlabMemberFields, GitlabProjectFields},
+        project::{GitlabMemberFields, GitlabProjectFields, GitlabProjectTagFields},
         release::GitlabReleaseFields,
         user::GitlabUserFields,
     },
@@ -368,6 +368,7 @@ paged!(
 paged!(github_list_user_gists, GithubGistFields, Gist);
 
 paged!(github_list_repo_tags, GithubRepositoryTagFields, Tag);
+paged!(gitlab_list_project_tags, GitlabProjectTagFields, Tag);
 
 // Single HTTP requests
 


### PR DESCRIPTION
Implement `gr pj tags` command so we can retrieve latest tags off of any
repository without doing a git clone.