### PR TITLE
Inject env var callback to config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "git-ar"
-version = "0.1.92"
+version = "0.1.93"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-ar"
-version = "0.1.92"
+version = "0.1.93"
 edition = "2021"
 
 license = "MIT"

--- a/doc/src/configuration.md
+++ b/doc/src/configuration.md
@@ -120,6 +120,7 @@ API types:
 - Pipeline
 - Release
 - Container registry
+- Repository tags
 
 ### Maximum pages to retrieve per API type
 
@@ -151,6 +152,10 @@ a per API basis.
   information about container registry images in the current project. This is
   supported in Gitlab only. This takes place in list operations in the `dk`
   subcommand.
+
+- `<domain>.max_pages_api_repository_tags=<number>` This API type is used to
+  retrieve information about tags in a repository. This takes place when listing
+  repository tags using the `gr pj tags` subcommand.
 
 ### Local cache duration for each API type
 
@@ -202,6 +207,9 @@ Cache duration for each API type is as follows:
 - `<domain>.cache_api_single_page_expiration=<number><time-unit>` This API type
   is used to retrieve information about single page calls. For example, trending
   repositories in github.com. A value of `1d` is recommended for this API type.
+
+- `<domain>.cache_api_repository_tags_expiration=<number><time-unit>` This API
+  type is used to retrieve information about tags in a repository.
 
 >**Note**: Local cache can be automatically expired and refreshed by issuing the
 `-r` flag when running the `gr` command.

--- a/src/gitlab/project.rs
+++ b/src/gitlab/project.rs
@@ -107,6 +107,11 @@ impl<R: HttpRunner<Response = Response>> RemoteTag for Gitlab<R> {
         )?;
         Ok(tags)
     }
+    // NOTE: For num_resources and num_pages, the ApiOperation::Project from the
+    // RemoteProject trait is being used, but those operations involve a single
+    // HEAD request, which is not cached and does not require pagination. So,
+    // technically speaking is not required. Might be a TODO to change/add an
+    // ApiOperation to reflect this.
 }
 
 impl<R> Gitlab<R> {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -7,7 +7,7 @@ use crate::api_traits::{
     DeployAsset, MergeRequest, RemoteProject, RemoteTag, TrendingProjectURL, UserInfo,
 };
 use crate::cache::{filesystem::FileCache, nocache::NoCache};
-use crate::config::{ConfigFile, NoConfig};
+use crate::config::{env_token, ConfigFile, NoConfig};
 use crate::display::Format;
 use crate::error::GRError;
 use crate::github::Github;
@@ -524,11 +524,11 @@ pub fn get_domain_path<R: TaskRunner<Response = Response>>(
 pub fn read_config(config_file: &Path, domain: &str) -> Result<Arc<dyn ConfigProperties>> {
     match File::open(config_file) {
         Ok(f) => {
-            let config = ConfigFile::new(f, domain)?;
+            let config = ConfigFile::new(f, domain, env_token)?;
             Ok(Arc::new(config))
         }
         Err(_) => {
-            let config = NoConfig::new(domain)?;
+            let config = NoConfig::new(domain, env_token)?;
             Ok(Arc::new(config))
         }
     }

--- a/tests/read_config_test.rs
+++ b/tests/read_config_test.rs
@@ -46,19 +46,19 @@ fn test_read_config_file_not_found_with_token_env_var_is_ok() {
 #[test]
 fn test_read_config_empty_file() {
     let temp_file = create_temp_config_file("");
-    let result = read_config(temp_file.path(), "githubmo.com");
+    let result = read_config(temp_file.path(), "github.com");
     assert!(result.is_err());
 }
 
 #[test]
 fn test_read_config_invalid_data() {
     let config_content = r#"
-    githubjd.com.api_token=1234
+    github.com.api_token=1234
     # Missing cache_location - This is still a valid config where key has no value
-    githubjd.com.cache_location
+    github.com.cache_location
     "#;
     let temp_file = create_temp_config_file(config_content);
-    let config = read_config(temp_file.path(), "githubjd.com").unwrap();
+    let config = read_config(temp_file.path(), "github.com").unwrap();
     assert_eq!(config.api_token(), "1234");
     assert!(config.cache_location().is_none());
 }


### PR DESCRIPTION
This is to avoid potential flaky tests by setting/unsetting env vars and
having to come up with unique domains every time we test a new config
option.