### PR TITLE
Move configuration over to TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +904,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror",
+ "toml",
  "ureq",
  "yaml-rust2",
 ]
@@ -1078,6 +1085,16 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1516,6 +1533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,6 +1731,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2081,6 +2141,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yaml-rust2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ env_logger = "0.11.5"
 yaml-rust2 = "0.8.1"
 rand = "0.8.5"
 paste = "1.0"
+toml = "0.8.19"
 
 [dev-dependencies]
 # disable basic-cookies from httpmock - not needed

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ your path.
 Or you can build from source. Building from source requires the latest stable
 release of Rust.
 
+>**NOTE:** If you decide to build from source at this moment, please be aware
+that the `main` branch breaks backward compatibility with the current
+configuration. It uses **TOML**. Please see unit tests for examples in the
+`src/config.rs` file.
+
 ```bash
 cargo build --release
 ./target/release/gr --help

--- a/src/api_defaults.rs
+++ b/src/api_defaults.rs
@@ -16,3 +16,5 @@ pub const DEFAULT_NUMBER_REQUESTS_MINUTE: u32 = 80;
 // Default number of results per page for --num-resources. Gitlab 20, Github 30
 // As this is an approximation, we will use 30 if per_page is not provided.
 pub const DEFAULT_PER_PAGE: u32 = 30;
+
+pub const EXPIRE_IMMEDIATELY: &'static str = "0s";

--- a/src/api_defaults.rs
+++ b/src/api_defaults.rs
@@ -17,4 +17,4 @@ pub const DEFAULT_NUMBER_REQUESTS_MINUTE: u32 = 80;
 // As this is an approximation, we will use 30 if per_page is not provided.
 pub const DEFAULT_PER_PAGE: u32 = 30;
 
-pub const EXPIRE_IMMEDIATELY: &'static str = "0s";
+pub const EXPIRE_IMMEDIATELY: &str = "0s";

--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -1,4 +1,6 @@
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
+
+use serde::Deserialize;
 
 use crate::{
     cli::browse::BrowseOptions,
@@ -192,6 +194,34 @@ impl Display for ApiOperation {
             ApiOperation::SinglePage => write!(f, "single_page"),
             ApiOperation::Gist => write!(f, "gist"),
             ApiOperation::RepositoryTag => write!(f, "repository_tag"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ApiOperation {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        ApiOperation::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl FromStr for ApiOperation {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<ApiOperation, std::string::String> {
+        match s.to_lowercase().as_str() {
+            "merge_request" => Ok(ApiOperation::MergeRequest),
+            "pipeline" => Ok(ApiOperation::Pipeline),
+            "project" => Ok(ApiOperation::Project),
+            "container_registry" => Ok(ApiOperation::ContainerRegistry),
+            "release" => Ok(ApiOperation::Release),
+            "single_page" => Ok(ApiOperation::SinglePage),
+            "gist" => Ok(ApiOperation::Gist),
+            "repository_tag" => Ok(ApiOperation::RepositoryTag),
+            _ => Err(format!("Unknown ApiOperation: {}", s)),
         }
     }
 }

--- a/src/cmds/browse.rs
+++ b/src/cmds/browse.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use crate::cli::browse::BrowseOptions;
-use crate::config::ConfigFile;
+use crate::config::ConfigProperties;
 use crate::remote;
 use crate::remote::CacheType;
 use crate::Result;
 
 pub fn execute(
     options: BrowseOptions,
-    config: Arc<ConfigFile>,
+    config: Arc<dyn ConfigProperties>,
     domain: String,
     path: String,
 ) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,16 +156,6 @@ impl ConfigFile {
                     ))
                 })?);
             }
-            // NOTE: This has a penalty of cloning internal contents but config
-            // is small and this is a one-time operation. Another design option,
-            // would be to split configurations for each domain in different
-            // files.
-            // Ex:
-            // ~/.config/gitar/gitlab.com
-            // ~/.config/gitar/github.com
-            // ~/.config/gitar/gitlab.company.com
-            // hence avoiding multiple domain configurations in one single file
-            // and avoiding domain config retrieval by domain key.
             Ok(ConfigFile {
                 inner: config,
                 domain: domain_key,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,10 @@
 //! Config file parsing and validation.
 
-use crate::api_defaults::{RATE_LIMIT_REMAINING_THRESHOLD, REST_API_MAX_PAGES};
+use crate::api_defaults::{EXPIRE_IMMEDIATELY, RATE_LIMIT_REMAINING_THRESHOLD, REST_API_MAX_PAGES};
 use crate::api_traits::ApiOperation;
 use crate::error::{self, GRError};
 use crate::Result;
+use serde::Deserialize;
 use std::sync::Arc;
 use std::{collections::HashMap, io::Read};
 
@@ -59,16 +60,33 @@ impl ConfigProperties for NoConfig {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-pub struct ConfigFile {
-    api_token: String,
+#[derive(Deserialize, Clone, Debug)]
+struct ApiSettings {
+    #[serde(flatten)]
+    settings: HashMap<ApiOperation, String>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+struct MaxPagesApi {
+    #[serde(flatten)]
+    settings: HashMap<ApiOperation, u32>,
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct DomainConfig {
+    api_token: Option<String>,
     cache_location: Option<String>,
-    preferred_assignee_username: String,
-    merge_request_description_signature: String,
-    // TODO, should be <ApiOperation, Seconds>
-    cache_expirations: HashMap<ApiOperation, String>,
-    max_pages: HashMap<ApiOperation, u32>,
-    rate_limit_remaining_threshold: u32,
+    preferred_assignee_username: Option<String>,
+    merge_request_description_signature: Option<String>,
+    rate_limit_remaining_threshold: Option<u32>,
+    cache_expirations: Option<ApiSettings>,
+    max_pages_api: Option<MaxPagesApi>,
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct ConfigFile {
+    #[serde(flatten)]
+    domains: HashMap<String, DomainConfig>,
 }
 
 pub fn env_token(domain: &str) -> Result<String> {
@@ -90,214 +108,54 @@ fn env_var(domain: &str) -> String {
 impl ConfigFile {
     // TODO: make use of a BufReader instead
     pub fn new<T: Read, FE: Fn(&str) -> Result<String>>(
-        reader: T,
+        mut reader: T,
         domain: &str,
         env: FE,
-    ) -> Result<Self> {
-        let config = ConfigFile::parse(reader, domain)?;
-        let domain_config_data = config.get(domain).unwrap();
+    ) -> Result<DomainConfig> {
+        let mut config_data = String::new();
+        reader.read_to_string(&mut config_data)?;
+        let mut config: ConfigFile = toml::from_str(&config_data)?;
+
         // ENV VAR API token takes preference. For a given domain, we try to fetch
         // <DOMAIN>_API_TOKEN env var first, then we fallback to the config
         // file. Given a domain such as gitlab.com, the env var to be set is
         // GITLAB_API_TOKEN. If the domain is gitlab.<company>.com, the env var
         // to be set is GITLAB_<COMPANY>_API_TOKEN.
 
-        // TODO: inject env_token as a function so we can control it in tests
-        let api_token = env(domain).or_else(|_| -> Result<String> {
-            let token_res = domain_config_data.get("api_token").ok_or_else(|| {
-                error::gen(format!(
-                    "No api_token found for domain {} in config",
-                    domain
-                ))
-            })?;
-            Ok(token_res.to_string())
-        })?;
-        let cache_location = domain_config_data.get("cache_location").cloned();
-        let default_assignee_username = "".to_string();
-        let preferred_assignee_username = domain_config_data
-            .get("preferred_assignee_username")
-            .unwrap_or(&default_assignee_username);
-        let default_merge_request_description_signature = "".to_string();
-        let merge_request_description_signature = domain_config_data
-            .get("merge_request_description_signature")
-            .unwrap_or(&default_merge_request_description_signature);
-        let cache_expirations = ConfigFile::cache_expirations(domain_config_data);
-        let max_pages = ConfigFile::max_pages(domain_config_data);
-        let rate_limit_remaining_threshold = domain_config_data
-            .get("rate_limit_remaining_threshold")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(RATE_LIMIT_REMAINING_THRESHOLD);
-
-        Ok(ConfigFile {
-            api_token: api_token.to_string(),
-            cache_location,
-            preferred_assignee_username: preferred_assignee_username.to_string(),
-            merge_request_description_signature: merge_request_description_signature.to_string(),
-            cache_expirations,
-            max_pages,
-            rate_limit_remaining_threshold,
-        })
-    }
-
-    fn max_pages(domain_config_data: &HashMap<String, String>) -> HashMap<ApiOperation, u32> {
-        let mut max_pages: HashMap<ApiOperation, u32> = HashMap::new();
-        max_pages.insert(
-            ApiOperation::MergeRequest,
-            domain_config_data
-                .get("max_pages_api_merge_request")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(REST_API_MAX_PAGES),
-        );
-        max_pages.insert(
-            ApiOperation::Pipeline,
-            domain_config_data
-                .get("max_pages_api_pipeline")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(REST_API_MAX_PAGES),
-        );
-        max_pages.insert(
-            ApiOperation::Project,
-            domain_config_data
-                .get("max_pages_api_project")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(REST_API_MAX_PAGES),
-        );
-        max_pages.insert(
-            ApiOperation::ContainerRegistry,
-            domain_config_data
-                .get("max_pages_api_container_registry")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(REST_API_MAX_PAGES),
-        );
-        max_pages.insert(
-            ApiOperation::Release,
-            domain_config_data
-                .get("max_pages_api_release")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(REST_API_MAX_PAGES),
-        );
-        max_pages.insert(
-            ApiOperation::Gist,
-            domain_config_data
-                .get("max_pages_api_gist")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(REST_API_MAX_PAGES),
-        );
-        max_pages.insert(
-            ApiOperation::RepositoryTag,
-            domain_config_data
-                .get("max_pages_api_repository_tags")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(REST_API_MAX_PAGES),
-        );
-        max_pages
-    }
-
-    fn cache_expirations(
-        domain_config_data: &HashMap<String, String>,
-    ) -> HashMap<ApiOperation, String> {
-        let mut cache_expirations: HashMap<ApiOperation, String> = HashMap::new();
-        cache_expirations.insert(
-            ApiOperation::MergeRequest,
-            domain_config_data
-                .get("cache_api_merge_request_expiration")
-                .unwrap_or(&"0s".to_string())
-                .to_string(),
-        );
-        cache_expirations.insert(
-            ApiOperation::Pipeline,
-            domain_config_data
-                .get("cache_api_pipeline_expiration")
-                .unwrap_or(&"0s".to_string())
-                .to_string(),
-        );
-        cache_expirations.insert(
-            ApiOperation::Project,
-            domain_config_data
-                .get("cache_api_project_expiration")
-                .unwrap_or(&"0s".to_string())
-                .to_string(),
-        );
-        cache_expirations.insert(
-            ApiOperation::ContainerRegistry,
-            domain_config_data
-                .get("cache_api_container_registry_expiration")
-                .unwrap_or(&"0s".to_string())
-                .to_string(),
-        );
-        cache_expirations.insert(
-            ApiOperation::Release,
-            domain_config_data
-                .get("cache_api_release_expiration")
-                .unwrap_or(&"0s".to_string())
-                .to_string(),
-        );
-        cache_expirations.insert(
-            ApiOperation::SinglePage,
-            domain_config_data
-                .get("cache_api_single_page_expiration")
-                .unwrap_or(&"0s".to_string())
-                .to_string(),
-        );
-        cache_expirations.insert(
-            ApiOperation::Gist,
-            domain_config_data
-                .get("cache_api_gist_expiration")
-                .unwrap_or(&"0s".to_string())
-                .to_string(),
-        );
-        cache_expirations.insert(
-            ApiOperation::RepositoryTag,
-            domain_config_data
-                .get("cache_api_repository_tags_expiration")
-                .unwrap_or(&"0s".to_string())
-                .to_string(),
-        );
-        cache_expirations
-    }
-
-    fn parse<T: Read>(
-        mut reader: T,
-        domain: &str,
-    ) -> Result<HashMap<String, HashMap<String, String>>> {
-        let mut config_data = String::new();
-        reader.read_to_string(&mut config_data)?;
-        let lines = config_data.lines();
-        let mut config = HashMap::new();
-        let mut domain_config = HashMap::new();
-
-        let regex =
-            regex::Regex::new(&format!(r"^{}\.(?P<key>\w+)=(?P<value>.*)", domain)).unwrap();
-        for line in lines {
-            let line = line.trim();
-            if line.is_empty() || line.starts_with('#') {
-                continue;
+        let domain_key = domain.replace('.', "_");
+        if let Some(domain_config) = config.domains.get_mut(&domain_key) {
+            if domain_config.api_token.is_none() {
+                domain_config.api_token = Some(env(domain).or_else(|_| -> Result<String> {
+                    Err(error::gen(format!(
+                        "No api_token found for domain {} in config or environment variable {}",
+                        domain,
+                        env_var(domain)
+                    )))
+                })?);
             }
-            // capture groups key and value from regex
-            let captured_names = regex.captures(line);
-            match captured_names {
-                Some(captured_names) => {
-                    let key = captured_names.name("key").unwrap().as_str();
-                    let value = captured_names.name("value").unwrap().as_str();
-                    domain_config.insert(key.to_string(), value.to_string());
-                }
-                None => {
-                    continue;
-                }
-            }
+            // NOTE: This has a penalty of cloning internal contents but config
+            // is small and this is a one-time operation. Another design option,
+            // would be to split configurations for each domain in different
+            // files.
+            // Ex:
+            // ~/.config/gitar/gitlab.com
+            // ~/.config/gitar/github.com
+            // ~/.config/gitar/gitlab.company.com
+            // hence avoiding multiple domain configurations in one single file
+            // and avoiding domain config retrieval by domain key.
+            Ok(domain_config.clone())
+        } else {
+            return Err(error::gen(format!(
+                "No config data found for domain {}",
+                domain
+            )));
         }
-
-        config.insert(domain.to_string(), domain_config);
-        if config.is_empty() {
-            return Err(error::gen("No config data found"));
-        }
-        Ok(config)
     }
 }
 
-impl ConfigProperties for ConfigFile {
+impl ConfigProperties for DomainConfig {
     fn api_token(&self) -> &str {
-        &self.api_token
+        &self.api_token.as_deref().unwrap_or_default()
     }
 
     fn cache_location(&self) -> Option<&str> {
@@ -305,35 +163,42 @@ impl ConfigProperties for ConfigFile {
     }
 
     fn preferred_assignee_username(&self) -> &str {
-        &self.preferred_assignee_username
+        &self
+            .preferred_assignee_username
+            .as_deref()
+            .unwrap_or_default()
     }
 
     fn merge_request_description_signature(&self) -> &str {
-        &self.merge_request_description_signature
+        &self
+            .merge_request_description_signature
+            .as_deref()
+            .unwrap_or_default()
     }
 
     fn get_cache_expiration(&self, api_operation: &ApiOperation) -> &str {
-        let expiration = self.cache_expirations.get(api_operation);
-        match expiration {
-            Some(expiration) => expiration,
-            None => "",
-        }
+        self.cache_expirations
+            .as_ref()
+            .and_then(|cache_expirations| cache_expirations.settings.get(api_operation))
+            .map(|s| s.as_str())
+            .unwrap_or_else(|| EXPIRE_IMMEDIATELY)
     }
 
     fn get_max_pages(&self, api_operation: &ApiOperation) -> u32 {
-        let max_pages = self.max_pages.get(api_operation);
-        match max_pages {
-            Some(max_pages) => *max_pages,
-            None => REST_API_MAX_PAGES,
-        }
+        self.max_pages_api
+            .as_ref()
+            .and_then(|max_pages| max_pages.settings.get(api_operation))
+            .map(|s| *s)
+            .unwrap_or(REST_API_MAX_PAGES)
     }
 
     fn rate_limit_remaining_threshold(&self) -> u32 {
         self.rate_limit_remaining_threshold
+            .unwrap_or(RATE_LIMIT_REMAINING_THRESHOLD)
     }
 }
 
-impl ConfigProperties for Arc<ConfigFile> {
+impl ConfigProperties for Arc<DomainConfig> {
     fn api_token(&self) -> &str {
         self.as_ref().api_token()
     }
@@ -372,41 +237,78 @@ mod test {
     }
 
     #[test]
-    fn test_get_api_token() {
+    fn test_config_ok() {
         let config_data = r#"
-        gitlabab.com.api_token=1234
-        githubab.com.api_token=4567
-        gitlabab.com.cache_location=/home/user/.config/mr_cache
-        githubab.com.cache_location=/home/user/.config/mr_cache
+        [gitlab_com]
+        api_token = '1234'
+        cache_location = "/home/user/.config/mr_cache"
+        preferred_assignee_username = 'jordilin'
+        rate_limit_remaining_threshold=15
+
+        [gitlab_com.max_pages_api]
+        merge_request = 2
+        pipeline = 3
+        project = 4
+        container_registry = 5
+        single_page = 6
+        release = 7
+        gist = 8
+        repository_tag = 9
+
+        [gitlab_com.cache_expirations]
+        merge_request = "30m"
+        pipeline = "0s"
+        project = "90d"
+        container_registry = "0s"
+        single_page = "0s"
+        release = "4h"
+        gist = "1w"
+        repository_tag = "0s"
         "#;
-        let domain = "gitlabab.com";
+        let domain = "gitlab.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
         assert_eq!("1234", config.api_token());
-    }
+        assert_eq!(
+            "/home/user/.config/mr_cache",
+            config.cache_location().unwrap()
+        );
+        assert_eq!(15, config.rate_limit_remaining_threshold());
+        assert_eq!("jordilin", config.preferred_assignee_username());
+        assert_eq!(2, config.get_max_pages(&ApiOperation::MergeRequest));
+        assert_eq!(3, config.get_max_pages(&ApiOperation::Pipeline));
+        assert_eq!(4, config.get_max_pages(&ApiOperation::Project));
+        assert_eq!(5, config.get_max_pages(&ApiOperation::ContainerRegistry));
+        assert_eq!(6, config.get_max_pages(&ApiOperation::SinglePage));
+        assert_eq!(7, config.get_max_pages(&ApiOperation::Release));
+        assert_eq!(8, config.get_max_pages(&ApiOperation::Gist));
+        assert_eq!(9, config.get_max_pages(&ApiOperation::RepositoryTag));
 
-    #[test]
-    fn test_ignore_commented_out_lines_and_empty_lines() {
-        let config_data = r#"
-
-        # api token
-        gitlababc.com.api_token=1234
-        githubabc.com.api_token=4567
-        gitlababc.com.cache_location=/home/user/.config/mr_cache
-        githubabc.com.cache_location=/home/user/.config/mr_cache
-        "#;
-        let domain = "gitlababc.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!("1234", config.api_token());
+        assert_eq!(
+            "30m",
+            config.get_cache_expiration(&ApiOperation::MergeRequest)
+        );
+        assert_eq!("0s", config.get_cache_expiration(&ApiOperation::Pipeline));
+        assert_eq!("90d", config.get_cache_expiration(&ApiOperation::Project));
+        assert_eq!(
+            "0s",
+            config.get_cache_expiration(&ApiOperation::ContainerRegistry)
+        );
+        assert_eq!("0s", config.get_cache_expiration(&ApiOperation::SinglePage));
+        assert_eq!("4h", config.get_cache_expiration(&ApiOperation::Release));
+        assert_eq!("1w", config.get_cache_expiration(&ApiOperation::Gist));
+        assert_eq!(
+            "0s",
+            config.get_cache_expiration(&ApiOperation::RepositoryTag)
+        );
     }
 
     #[test]
     fn test_no_api_token_is_err() {
         let config_data = r#"
-        # api token
-        gitlabde.com.api_token_typo=1234"#;
-        let domain = "gitlabde.com";
+        [gitlab_com]
+        api_token_typo=1234"#;
+        let domain = "gitlab.com";
         let reader = std::io::Cursor::new(config_data);
         assert!(ConfigFile::new(reader, domain, no_env).is_err());
     }
@@ -414,234 +316,27 @@ mod test {
     #[test]
     fn test_config_no_data() {
         let config_data = "";
-        let domain = "gitlabdef.com";
+        let domain = "gitlab.com";
         let reader = std::io::Cursor::new(config_data);
         assert!(ConfigFile::new(reader, domain, no_env).is_err());
-    }
-
-    #[test]
-    fn test_config_multiple_equals() {
-        let config_data = "gitlabfg_api_token===1234";
-        let domain = "gitlabfg.com";
-        let reader = std::io::Cursor::new(config_data);
-        assert!(ConfigFile::new(reader, domain, no_env).is_err());
-    }
-
-    #[test]
-    fn test_get_preferred_assignee_username() {
-        let config_data = r#"
-        githubhe.com.api_token=1234
-        githubhe.com.cache_location=/home/user/.config/mr_cache
-        githubhe.com.preferred_assignee_username=jordilin"#;
-        let domain = "githubhe.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!("jordilin", config.preferred_assignee_username());
-    }
-
-    #[test]
-    fn test_get_merge_request_description_signature() {
-        let config_data = r#"
-        githuble.com.api_token=1234
-        githuble.com.cache_location=/home/user/.config/mr_cache
-        githuble.com.preferred_assignee_username=jordilin
-        githuble.com.merge_request_description_signature=- devops team :-)"#;
-        let domain = "githuble.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(
-            "- devops team :-)",
-            config.merge_request_description_signature()
-        );
-    }
-
-    #[test]
-    fn test_config_cache_api_expirations() {
-        let config_data = r#"
-        githubza.com.api_token=1234
-        githubza.com.cache_location=/home/user/.config/mr_cache
-        githubza.com.preferred_assignee_username=jordilin
-        githubza.com.merge_request_description_signature=- devops team :-)
-        githubza.com.cache_api_merge_request_expiration=2h
-        githubza.com.cache_api_pipeline_expiration=1h
-        githubza.com.cache_api_project_expiration=3h
-        githubza.com.cache_api_container_registry_expiration=4h
-        githubza.com.cache_api_single_page_expiration=1d
-        githubza.com.cache_api_release_expiration=5h
-        githubza.com.cache_api_gist_expiration=1d"#;
-        let domain = "githubza.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(
-            "2h",
-            config.get_cache_expiration(&ApiOperation::MergeRequest)
-        );
-        assert_eq!("1h", config.get_cache_expiration(&ApiOperation::Pipeline));
-        assert_eq!("3h", config.get_cache_expiration(&ApiOperation::Project));
-        assert_eq!(
-            "4h",
-            config.get_cache_expiration(&ApiOperation::ContainerRegistry)
-        );
-        assert_eq!("5h", config.get_cache_expiration(&ApiOperation::Release));
-        assert_eq!("1d", config.get_cache_expiration(&ApiOperation::SinglePage));
-        assert_eq!("1d", config.get_cache_expiration(&ApiOperation::Gist));
     }
 
     #[test]
     fn test_config_cache_api_expiration_default() {
         let config_data = r#"
-        githubme.com.api_token=1234
-        githubme.com.cache_location=/home/user/.config/mr_cache
-        githubme.com.preferred_assignee_username=jordilin
-        githubme.com.merge_request_description_signature=- devops team :-)
+        [github_com]
+        api_token="1234"
+        cache_location="/home/user/.config/mr_cache"
+        preferred_assignee_username="jordilin"
+        merge_request_description_signature="- devops team :-)"
         "#;
-        let domain = "githubme.com";
+        let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
         let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
         assert_eq!(
             "0s",
             config.get_cache_expiration(&ApiOperation::MergeRequest)
         );
-    }
-
-    #[test]
-    fn test_config_max_pages_merge_requests() {
-        let config_data = r#"
-        githubpo.com.api_token=1234
-        githubpo.com.cache_location=/home/user/.config/mr_cache
-        githubpo.com.preferred_assignee_username=jordilin
-        githubpo.com.max_pages_api_merge_request=2
-        "#;
-        let domain = "githubpo.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(2, config.get_max_pages(&ApiOperation::MergeRequest));
-    }
-
-    #[test]
-    fn test_config_max_pages_default_merge_request() {
-        let config_data = r#"
-        github99.com.api_token=1234
-        github99.com.cache_location=/home/user/.config/mr_cache
-        github99.com.preferred_assignee_username=jordilin
-        "#;
-        let domain = "github99.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(
-            REST_API_MAX_PAGES,
-            config.get_max_pages(&ApiOperation::MergeRequest)
-        );
-    }
-
-    #[test]
-    fn test_config_max_pages_pipeline() {
-        let config_data = r#"
-        github00.com.api_token=1234
-        github00.com.cache_location=/home/user/.config/mr_cache
-        github00.com.preferred_assignee_username=jordilin
-        github00.com.max_pages_api_pipeline=4
-        "#;
-        let domain = "github00.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(4, config.get_max_pages(&ApiOperation::Pipeline));
-    }
-
-    #[test]
-    fn test_config_max_pages_default_pipeline() {
-        let config_data = r#"
-        github.11.com.api_token=1234
-        github.11.com.cache_location=/home/user/.config/mr_cache
-        github.11.com.preferred_assignee_username=jordilin"#;
-        let domain = "github.11.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(
-            REST_API_MAX_PAGES,
-            config.get_max_pages(&ApiOperation::Pipeline)
-        );
-    }
-
-    #[test]
-    fn test_config_max_pages_project() {
-        let config_data = r#"
-        github44.com.api_token=1234
-        github44.com.cache_location=/home/user/.config/mr_cache
-        github44.com.preferred_assignee_username=jordilin
-        github44.com.max_pages_api_project=6
-        "#;
-        let domain = "github44.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(6, config.get_max_pages(&ApiOperation::Project));
-    }
-
-    #[test]
-    fn test_config_max_pages_default_project() {
-        let config_data = r#"
-        github23.com.api_token=1234
-        github23.com.cache_location=/home/user/.config/mr_cache
-        github23.com.preferred_assignee_username=jordilin"#;
-        let domain = "github23.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(
-            REST_API_MAX_PAGES,
-            config.get_max_pages(&ApiOperation::Project)
-        );
-    }
-
-    #[test]
-    fn test_get_rate_limit_remaining_threshold() {
-        let config_data = r#"
-        gitlab66.com.api_token=1234
-        gitlab66.com.cache_location=/home/user/.config/mr_cache
-        gitlab66.com.rate_limit_remaining_threshold=15
-        "#;
-        let domain = "gitlab66.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(15, config.rate_limit_remaining_threshold());
-    }
-
-    #[test]
-    fn test_get_max_pages_for_container_registry_operations() {
-        let config_data = r#"
-        gitlab77.com.api_token=1234
-        gitlab77.com.cache_location=/home/user/.config/mr_cache
-        gitlab77.com.max_pages_api_container_registry=15
-        "#;
-        let domain = "gitlab77.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(15, config.get_max_pages(&ApiOperation::ContainerRegistry));
-    }
-
-    #[test]
-    fn test_get_max_pages_for_read_releases() {
-        let config_data = r#"
-        gitlabed.com.api_token=1234
-        gitlabed.com.cache_location=/home/user/.config/mr_cache
-        gitlabed.com.max_pages_api_release=15
-        "#;
-        let domain = "gitlabed.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(15, config.get_max_pages(&ApiOperation::Release));
-    }
-
-    #[test]
-    fn test_get_max_pages_for_gists() {
-        let config_data = r#"
-        gitlabty.com.api_token=1234
-        gitlabty.com.cache_location=/home/user/.config/mr_cache
-        gitlabty.com.max_pages_api_gist=15
-        "#;
-        let domain = "gitlabty.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(15, config.get_max_pages(&ApiOperation::Gist));
     }
 
     fn env(_: &str) -> Result<String> {
@@ -651,8 +346,9 @@ mod test {
     #[test]
     fn test_use_gitlab_com_api_token_envvar() {
         let config_data = r#"
-        gitlab.com.cache_location=/home/user/.config/mr_cache
-        gitlab.com.rate_limit_remaining_threshold=15
+        [gitlab_com]
+        cache_location="/home/user/.config/mr_cache"
+        rate_limit_remaining_threshold=15
         "#;
         let domain = "gitlab.com";
         let reader = std::io::Cursor::new(config_data);
@@ -661,22 +357,11 @@ mod test {
     }
 
     #[test]
-    fn test_use_github_com_api_token_envvar() {
-        let config_data = r#"
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.rate_limit_remaining_threshold=15
-        "#;
-        let domain = "github.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, env).unwrap());
-        assert_eq!("1234", config.api_token());
-    }
-
-    #[test]
     fn test_use_sub_domain_gitlab_token_env_var() {
         let config_data = r#"
-        gitlab.company.com.cache_location=/home/user/.config/mr_cache
-        gitlab.company.com.rate_limit_remaining_threshold=15
+        [gitlab_company_com]
+        cache_location="/home/user/.config/mr_cache"
+        rate_limit_remaining_threshold=15
         "#;
         let domain = "gitlab.company.com";
         let reader = std::io::Cursor::new(config_data);
@@ -685,10 +370,11 @@ mod test {
     }
 
     #[test]
-    fn test_domain_without_top_leven_domain_token_envvar() {
+    fn test_domain_without_top_level_domain_token_envvar() {
         let config_data = r#"
-        gitlabweb.cache_location=/home/user/.config/mr_cache
-        gitlabweb.rate_limit_remaining_threshold=15
+        [gitlabweb]
+        cache_location="/home/user/.config/mr_cache"
+        rate_limit_remaining_threshold=15
         "#;
         let domain = "gitlabweb";
         let reader = std::io::Cursor::new(config_data);
@@ -717,72 +403,5 @@ mod test {
             },
             _ => panic!("Expected error"),
         }
-    }
-
-    #[test]
-    fn test_config_cache_api_expiration_for_repository_tags() {
-        let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin
-        github.com.merge_request_description_signature=- devops team :-)
-        github.com.cache_api_repository_tags_expiration=2h
-        "#;
-        let domain = "github.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(
-            "2h",
-            config.get_cache_expiration(&ApiOperation::RepositoryTag)
-        );
-    }
-
-    #[test]
-    fn test_cache_expiration_for_repository_tags_is_zero_if_not_provided() {
-        let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin
-        github.com.merge_request_description_signature=- devops team :-)
-        "#;
-        let domain = "github.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(
-            "0s",
-            config.get_cache_expiration(&ApiOperation::RepositoryTag)
-        );
-    }
-
-    #[test]
-    fn test_get_max_pages_for_repository_tags() {
-        let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin
-        github.com.merge_request_description_signature=- devops team :-)
-        github.com.max_pages_api_repository_tags=15
-        "#;
-        let domain = "github.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(15, config.get_max_pages(&ApiOperation::RepositoryTag));
-    }
-
-    #[test]
-    fn test_get_max_pages_repository_tags_default_if_none_provided() {
-        let config_data = r#"
-        github.com.api_token=1234
-        github.com.cache_location=/home/user/.config/mr_cache
-        github.com.preferred_assignee_username=jordilin
-        github.com.merge_request_description_signature=- devops team :-)
-        "#;
-        let domain = "github.com";
-        let reader = std::io::Cursor::new(config_data);
-        let config = Arc::new(ConfigFile::new(reader, domain, no_env).unwrap());
-        assert_eq!(
-            REST_API_MAX_PAGES,
-            config.get_max_pages(&ApiOperation::RepositoryTag)
-        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,12 +149,11 @@ impl ConfigFile {
         let domain_key = domain.replace('.', "_");
         if let Some(domain_config) = config.domains.get_mut(&domain_key) {
             if domain_config.api_token.is_none() {
-                domain_config.api_token = Some(env(domain).or_else(|_| -> Result<String> {
-                    Err(error::gen(format!(
-                        "No api_token found for domain {} in config or environment variable {}",
-                        domain,
-                        env_var(domain)
-                    )))
+                domain_config.api_token = Some(env(domain).map_err(|_| {
+                    GRError::PreconditionNotMet(format!(
+                        "No api_token found for domain {} in config or environment variable",
+                        domain
+                    ))
                 })?);
             }
             // NOTE: This has a penalty of cloning internal contents but config
@@ -173,10 +172,10 @@ impl ConfigFile {
                 project_path: project_path.to_string(),
             })
         } else {
-            return Err(error::gen(format!(
+            Err(error::gen(format!(
                 "No config data found for domain {}",
                 domain
-            )));
+            )))
         }
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -10,52 +10,58 @@ const CONFIG_TEMPLATE: &str = r#"
 # Fill in the <VALUE> below with your own values
 # and tweak accordingly.
 
-<DOMAIN>.api_token=<VALUE>
-<DOMAIN>.cache_location="~/.cache/gitar"
-<DOMAIN>.preferred_assignee_username=<VALUE>
-<DOMAIN>.merge_request_description_signature=""
+# NOTE: Substitute domain '.' for '_' in the section name
+# Ex. if DOMAIN is gitlab.com -> [gitlab_com]
+# Ex. if DOMAIN is gitlab.example.com -> [gitlab_example_com]
 
-## Cache expiration configuration
+[<DOMAIN>]
 
-# Expire read merge requests in 5 minutes
-<DOMAIN>.cache_api_merge_request_expiration=5m
-# Expire read project metadata, members of a project in 5 days
-<DOMAIN>.cache_api_project_expiration=5d
-# Pipelines are read often, change often, so expire soon.
-<DOMAIN>.cache_api_pipeline_expiration=30s
-# Container registry operations including listing image tags and repos
-<DOMAIN>.cache_api_container_registry_expiration=1h
-# Expire read releases in 1 day
-<DOMAIN>.cache_api_release_expiration=1d
-# Expire single page calls in 1 day. Ex. Trending repositories in github.com
-<DOMAIN>.cache_api_single_page_expiration=1d
-# Expire your user gists in 1 day
-<DOMAIN>.cache_api_gist_expiration=1d
-# Expire repository tags immediately
-<DOMAIN>.cache_api_repository_tags_expiration=0s
-
-## Max pages configuration
-
-# Get up to 10 pages of merge requests when listing
-<DOMAIN>.max_pages_api_merge_request=10
-# Get up to 5 pages of project metadata, members of a project when listing
-<DOMAIN>.max_pages_api_project=5
-# Get up to 10 pages of pipelines when listing
-<DOMAIN>.max_pages_api_pipeline=10
-# Get up to 10 pages of container registry repositories when listing
-<DOMAIN>.max_pages_api_container_registry=10
-# Get up to 10 pages of releases when listing
-<DOMAIN>.max_pages_api_release=10
-# Get up to 5 pages of your gists
-<DOMAIN>.max_pages_api_gist=5
-# Get up to 10 pages of tags when listing
-<DOMAIN>.max_pages_api_repository_tags=10
+api_token="<VALUE>"
+cache_location=".cache/gitar"
+preferred_assignee_username="<VALUE>"
+merge_request_description_signature=""
 
 # Rate limit remaining threshold. Threshold by which the tool will stop
 # processing requests. Defaults to 10 if not provided. The remote has a counter
 # that decreases with each request. When we reach this threshold we stop for safety.
 # When it reaches 0 the remote will throw errors.
-<DOMAIN>.rate_limit_remaining_threshold=10
+rate_limit_remaining_threshold=10
+
+[<DOMAIN>.cache_expirations]
+
+# Expire read merge requests in 5 minutes
+merge_request="5m"
+# Expire read project metadata, members of a project in 5 days
+project="5d"
+# Pipelines are read often, change often, so expire soon.
+pipeline="30s"
+# Container registry operations including listing image tags and repos
+container_registry="1h"
+# Expire read releases in 1 day
+release="1d"
+# Expire single page calls in 1 day. Ex. Trending repositories in github.com
+single_page="1d"
+# Expire your user gists in 1 day
+gist="1d"
+# Expire repository tags immediately
+repository_tags="0s"
+
+[<DOMAIN>.max_pages_api]
+
+# Get up to 10 pages of merge requests when listing
+merge_request=10
+# Get up to 5 pages of project metadata, members of a project when listing
+project=5
+# Get up to 10 pages of pipelines when listing
+pipeline=10
+# Get up to 10 pages of container registry repositories when listing
+container_registry=10
+# Get up to 10 pages of releases when listing
+release=10
+# Get up to 5 pages of your gists
+gist=5
+# Get up to 10 pages of tags when listing
+repository_tags=10
 
 ### Other domains - add more if needed
 "#;
@@ -101,7 +107,8 @@ fn persist_config<D: Into<String>, W: Write>(data: D, writer: &mut W) -> Result<
 }
 
 fn change_placeholders(domain: &str) -> String {
-    CONFIG_TEMPLATE.replace("<DOMAIN>", domain)
+    let domain = domain.replace(".", "_");
+    CONFIG_TEMPLATE.replace("<DOMAIN>", &domain)
 }
 
 #[cfg(test)]
@@ -112,13 +119,13 @@ mod test {
     #[test]
     fn test_persist_config() {
         let options = InitCommandOptions {
-            domain: "gitlab.com".to_string(),
+            domain: "gitweb.com".to_string(),
         };
         let mut writer = Vec::new();
         let result = generate_and_persist(options, &mut writer);
         assert!(result.is_ok());
         assert!(writer.len() > 0);
         let content = String::from_utf8(writer).unwrap();
-        assert!(content.contains("gitlab.com"));
+        assert!(content.contains("gitweb_com"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn handle_cli_options(
         }
         CliOptions::Browse(options) => {
             // Use default config for browsing - does not require auth.
-            let config = Arc::new(gr::config::ConfigFile::default());
+            let config = Arc::new(gr::config::DomainConfig::default());
             let requirements = vec![
                 CliDomainRequirements::RepoArgs,
                 CliDomainRequirements::CdInLocalRepo,
@@ -137,7 +137,7 @@ fn handle_cli_options(
         }
         CliOptions::Manual => browse::execute(
             BrowseOptions::Manual,
-            Arc::new(gr::config::ConfigFile::default()),
+            Arc::new(gr::config::DomainConfig::default()),
             "".to_string(),
             "".to_string(),
         ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,12 +51,12 @@ fn handle_cli_options(
             ];
             let (domain, path) =
                 remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
-            let config = remote::read_config(&config_file, &domain)?;
+            let config = remote::read_config(&config_file, &domain, &path)?;
             merge_request::execute(options, cli_args, config, domain, path)
         }
         CliOptions::Browse(options) => {
             // Use default config for browsing - does not require auth.
-            let config = Arc::new(gr::config::DomainConfig::default());
+            let config = Arc::new(gr::config::ConfigFile::default());
             let requirements = vec![
                 CliDomainRequirements::RepoArgs,
                 CliDomainRequirements::CdInLocalRepo,
@@ -72,7 +72,7 @@ fn handle_cli_options(
             ];
             let (domain, path) =
                 remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
-            let config = remote::read_config(&config_file, &domain)?;
+            let config = remote::read_config(&config_file, &domain, &path)?;
             cicd::execute(options, config, domain, path)
         }
         CliOptions::Project(options) => {
@@ -82,7 +82,7 @@ fn handle_cli_options(
             ];
             let (domain, path) =
                 remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
-            let config = remote::read_config(&config_file, &domain)?;
+            let config = remote::read_config(&config_file, &domain, &path)?;
             project::execute(options, config, domain, path)
         }
         CliOptions::Docker(options) => {
@@ -92,7 +92,7 @@ fn handle_cli_options(
             ];
             let (domain, path) =
                 remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
-            let config = remote::read_config(&config_file, &domain)?;
+            let config = remote::read_config(&config_file, &domain, &path)?;
             docker::execute(options, config, domain, path)
         }
         CliOptions::Release(options) => {
@@ -102,7 +102,7 @@ fn handle_cli_options(
             ];
             let (domain, path) =
                 remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
-            let config = remote::read_config(&config_file, &domain)?;
+            let config = remote::read_config(&config_file, &domain, &path)?;
             cmds::release::execute(options, config, domain, path)
         }
         CliOptions::My(options) => {
@@ -112,7 +112,7 @@ fn handle_cli_options(
             ];
             let (domain, path) =
                 remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
-            let config = remote::read_config(&config_file, &domain)?;
+            let config = remote::read_config(&config_file, &domain, &path)?;
             cmds::my::execute(options, config, domain, path)
         }
         CliOptions::Trending(options) => match options {
@@ -120,7 +120,7 @@ fn handle_cli_options(
                 // Trending repos is for github.com - Allow for `gr tr
                 // <language>` everywhere in the shell.
                 let domain = "github.com";
-                let config = remote::read_config(&config_file, domain)?;
+                let config = remote::read_config(&config_file, domain, "")?;
                 cmds::trending::execute(args, config, domain)
             }
         },
@@ -131,13 +131,14 @@ fn handle_cli_options(
                 CliDomainRequirements::RepoArgs,
                 CliDomainRequirements::CdInLocalRepo,
             ];
-            let (domain, _) = remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
-            let config = remote::read_config(&config_file, &domain)?;
+            let (domain, path) =
+                remote::get_domain_path(&cli_args, &requirements, &BlockingCommand)?;
+            let config = remote::read_config(&config_file, &domain, &path)?;
             cmds::cache::execute(options, config)
         }
         CliOptions::Manual => browse::execute(
             BrowseOptions::Manual,
-            Arc::new(gr::config::DomainConfig::default()),
+            Arc::new(gr::config::ConfigFile::default()),
             "".to_string(),
             "".to_string(),
         ),

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -521,10 +521,14 @@ pub fn get_domain_path<R: TaskRunner<Response = Response>>(
     .into())
 }
 
-pub fn read_config(config_file: &Path, domain: &str) -> Result<Arc<dyn ConfigProperties>> {
+pub fn read_config(
+    config_file: &Path,
+    domain: &str,
+    project_path: &str,
+) -> Result<Arc<dyn ConfigProperties>> {
     match File::open(config_file) {
         Ok(f) => {
-            let config = ConfigFile::new(f, domain, env_token)?;
+            let config = ConfigFile::new(f, domain, project_path, env_token)?;
             Ok(Arc::new(config))
         }
         Err(_) => {

--- a/tests/read_config_test.rs
+++ b/tests/read_config_test.rs
@@ -13,10 +13,9 @@ fn create_temp_config_file(content: &str) -> NamedTempFile {
 #[test]
 fn test_read_config_valid() {
     let config_content = r#"
-    github.test.com.api_token=1234
-    github.test.com.cache_location=/tmp/cache
-    gitlab.test.com.api_token=5678
-    gitlab.test.com.cache_location=/tmp/cache2
+    [github_test_com]
+    api_token="1234"
+    cache_location="/tmp/cache"
     "#;
     let temp_file = create_temp_config_file(config_content);
     let result = read_config(temp_file.path(), "github.test.com");
@@ -58,9 +57,7 @@ fn test_read_config_invalid_data() {
     github.com.cache_location
     "#;
     let temp_file = create_temp_config_file(config_content);
-    let config = read_config(temp_file.path(), "github.com").unwrap();
-    assert_eq!(config.api_token(), "1234");
-    assert!(config.cache_location().is_none());
+    assert!(read_config(temp_file.path(), "github.com").is_err());
 }
 
 #[test]

--- a/tests/read_config_test.rs
+++ b/tests/read_config_test.rs
@@ -18,7 +18,8 @@ fn test_read_config_valid() {
     cache_location="/tmp/cache"
     "#;
     let temp_file = create_temp_config_file(config_content);
-    let result = read_config(temp_file.path(), "github.test.com");
+    let project_path = "/jordilin/gitar";
+    let result = read_config(temp_file.path(), "github.test.com", project_path);
     assert!(result.is_ok());
     let config = result.unwrap();
     assert_eq!(config.api_token(), "1234");
@@ -27,9 +28,11 @@ fn test_read_config_valid() {
 
 #[test]
 fn test_read_config_file_not_found_and_no_token_env_var_is_error() {
+    let project_path = "/jordilin/gitar";
     let result = read_config(
         Path::new("/non/existent/path.txt"),
         "github.integrationtest.com",
+        project_path,
     );
     assert!(result.is_err());
 }
@@ -37,7 +40,12 @@ fn test_read_config_file_not_found_and_no_token_env_var_is_error() {
 #[test]
 fn test_read_config_file_not_found_with_token_env_var_is_ok() {
     std::env::set_var("INTEGRATIONTEST_API_TOKEN", "123");
-    let config_res = read_config(Path::new("/non/existent/path.txt"), "integrationtest.com");
+    let project_path = "/jordilin/gitar";
+    let config_res = read_config(
+        Path::new("/non/existent/path.txt"),
+        "integrationtest.com",
+        project_path,
+    );
     assert!(config_res.is_ok());
     std::env::remove_var("INTEGRATIONTEST_API_TOKEN");
 }
@@ -45,7 +53,8 @@ fn test_read_config_file_not_found_with_token_env_var_is_ok() {
 #[test]
 fn test_read_config_empty_file() {
     let temp_file = create_temp_config_file("");
-    let result = read_config(temp_file.path(), "github.com");
+    let project_path = "/jordilin/gitar";
+    let result = read_config(temp_file.path(), "github.com", project_path);
     assert!(result.is_err());
 }
 
@@ -56,8 +65,9 @@ fn test_read_config_invalid_data() {
     # Missing cache_location - This is still a valid config where key has no value
     github.com.cache_location
     "#;
+    let project_path = "/jordilin/gitar";
     let temp_file = create_temp_config_file(config_content);
-    assert!(read_config(temp_file.path(), "github.com").is_err());
+    assert!(read_config(temp_file.path(), "github.com", project_path).is_err());
 }
 
 #[test]
@@ -66,7 +76,8 @@ fn test_read_config_unknown_domain() {
     github.com.api_token=1234
     github.com.cache_location=/tmp/cache
     "#;
+    let project_path = "/jordilin/gitar";
     let temp_file = create_temp_config_file(config_content);
-    let result = read_config(temp_file.path(), "gitlab.com");
+    let result = read_config(temp_file.path(), "gitlab.com", project_path);
     assert!(result.is_err());
 }


### PR DESCRIPTION
In this merge request configuration moves over to TOML. This is to be able to
scale configuration with project based settings. Particularly, we will be able
to override assignee and merge request description on a per project basis if
needed.

This is the base to implement config based assignees and reviewers instead of
pulling all project users from the remote (future implementation).
