### PR TITLE
Provide configuration for merge request users

### DIFF
--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -662,7 +662,7 @@ fn cmds<R: BufRead + Send + Sync + 'static>(
     let remote_cl = remote.clone();
     let remote_project_cmd = move || -> Result<CmdInfo> { remote_cl.get_project_data(None, None) };
     let assignees_cmd = move || -> Result<CmdInfo> {
-        let assignees = config.assignees();
+        let assignees = config.merge_request_members();
         if assignees.is_some() {
             let mut assignees = assignees.unwrap();
             assignees.insert(

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -139,11 +139,7 @@ pub struct MergeRequestBodyArgs {
     #[builder(default)]
     pub target_branch: String,
     #[builder(default)]
-    pub assignee_id: String,
-    #[builder(default)]
     pub assignee: Member,
-    #[builder(default)]
-    pub username: String,
     #[builder(default = "String::from(\"true\")")]
     pub remove_source_branch: String,
     #[builder(default)]
@@ -567,8 +563,7 @@ fn user_prompt_confirmation(
             .source_branch(mr_body.repo.current_branch().to_string())
             .target_branch(target_branch.to_string())
             .target_repo(cli_args.target_repo.as_ref().unwrap().clone())
-            .assignee_id("".to_string())
-            .username("".to_string())
+            .assignee(Member::default())
             .remove_source_branch("true".to_string())
             .amend(cli_args.amend)
             .draft(cli_args.draft)
@@ -593,8 +588,6 @@ fn user_prompt_confirmation(
         .description(user_input.description)
         .source_branch(mr_body.repo.current_branch().to_string())
         .target_branch(target_branch.to_string())
-        .assignee_id(user_input.user_id.to_string())
-        .username(user_input.username)
         .assignee(user_input.assignee)
         // TODO make this configurable
         .remove_source_branch("true".to_string())
@@ -921,13 +914,17 @@ mod tests {
 
     #[test]
     fn test_merge_request_get_all_fields() {
+        let assignee = Member::builder()
+            .id(1)
+            .username("username".to_string())
+            .build()
+            .unwrap();
         let args = MergeRequestBodyArgs::builder()
             .source_branch("source".to_string())
             .target_branch("target".to_string())
             .title("title".to_string())
             .description("description".to_string())
-            .assignee_id("assignee_id".to_string())
-            .username("username".to_string())
+            .assignee(assignee)
             .remove_source_branch("false".to_string())
             .build()
             .unwrap();
@@ -936,8 +933,8 @@ mod tests {
         assert_eq!(args.target_branch, "target");
         assert_eq!(args.title, "title");
         assert_eq!(args.description, "description");
-        assert_eq!(args.assignee_id, "assignee_id");
-        assert_eq!(args.username, "username");
+        assert_eq!(args.assignee.id, 1);
+        assert_eq!(args.assignee.username, "username");
         assert_eq!(args.remove_source_branch, "false");
     }
 

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -570,9 +570,7 @@ fn user_prompt_confirmation(
             .build()?);
     }
     let user_input = if cli_args.auto {
-        let preferred_assignee_members = vec![config
-            .preferred_assignee_username()
-            .unwrap_or(Member::default())];
+        let preferred_assignee_members = [config.preferred_assignee_username().unwrap_or_default()];
         dialog::MergeRequestUserInput::builder()
             .title(title)
             .description(description)
@@ -661,8 +659,8 @@ fn cmds<R: BufRead + Send + Sync + 'static>(
         if assignees.is_some() {
             let mut assignees = assignees.unwrap();
             let default_assignee = config.preferred_assignee_username();
-            if default_assignee.is_some() {
-                assignees.insert(0, default_assignee.unwrap());
+            if let Some(assignee) = default_assignee {
+                assignees.insert(0, assignee);
                 // Allow client to unselect the default assignee
                 assignees.insert(1, Member::default());
             } else {

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -141,6 +141,8 @@ pub struct MergeRequestBodyArgs {
     #[builder(default)]
     pub assignee_id: String,
     #[builder(default)]
+    pub assignee: Member,
+    #[builder(default)]
     pub username: String,
     #[builder(default = "String::from(\"true\")")]
     pub remove_source_branch: String,
@@ -576,12 +578,12 @@ fn user_prompt_confirmation(
         let preferred_assignee_members = vec![config
             .preferred_assignee_username()
             .unwrap_or(Member::default())];
-        dialog::MergeRequestUserInput::new(
-            &title,
-            &description,
-            preferred_assignee_members[0].id,
-            &preferred_assignee_members[0].username,
-        )
+        dialog::MergeRequestUserInput::builder()
+            .title(title)
+            .description(description)
+            .assignee(preferred_assignee_members[0].clone())
+            .build()
+            .unwrap()
     } else {
         dialog::prompt_user_merge_request_info(&title, &description, &mr_body.members)?
     };
@@ -593,6 +595,7 @@ fn user_prompt_confirmation(
         .target_branch(target_branch.to_string())
         .assignee_id(user_input.user_id.to_string())
         .username(user_input.username)
+        .assignee(user_input.assignee)
         // TODO make this configurable
         .remove_source_branch("true".to_string())
         .draft(cli_args.draft)

--- a/src/cmds/project.rs
+++ b/src/cmds/project.rs
@@ -89,15 +89,27 @@ impl Timestamp for Project {
     }
 }
 
+/// MrMemberType is a merge request user type. The client might leave the
+/// assignee or reviewer empty.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum MrMemberType {
+    Filled,
+    #[default]
+    Empty,
+}
+
 #[derive(Builder, Clone, Debug, PartialEq, Default)]
 pub struct Member {
     #[builder(default)]
     pub id: i64,
     #[builder(default)]
     pub name: String,
+    #[builder(default)]
     pub username: String,
     #[builder(default)]
     pub created_at: String,
+    #[builder(default)]
+    pub mr_member_type: MrMemberType,
 }
 
 impl Member {

--- a/src/cmds/project.rs
+++ b/src/cmds/project.rs
@@ -91,6 +91,7 @@ impl Timestamp for Project {
 
 #[derive(Builder, Clone, Debug, PartialEq, Default)]
 pub struct Member {
+    #[builder(default)]
     pub id: i64,
     #[builder(default)]
     pub name: String,

--- a/src/cmds/project.rs
+++ b/src/cmds/project.rs
@@ -92,6 +92,7 @@ impl Timestamp for Project {
 #[derive(Builder, Clone, Debug, PartialEq, Default)]
 pub struct Member {
     pub id: i64,
+    #[builder(default)]
     pub name: String,
     pub username: String,
     #[builder(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 
 use crate::api_defaults::{EXPIRE_IMMEDIATELY, RATE_LIMIT_REMAINING_THRESHOLD, REST_API_MAX_PAGES};
 use crate::api_traits::ApiOperation;
-use crate::cmds::project::Member;
+use crate::cmds::project::{Member, MrMemberType};
 use crate::error::{self, GRError};
 use crate::Result;
 use serde::Deserialize;
@@ -222,11 +222,13 @@ impl ConfigFile {
                 .map(|user_info| match user_info {
                     UserInfo::UsernameOnly(username) => Member::builder()
                         .username(username.clone())
+                        .mr_member_type(MrMemberType::Filled)
                         .build()
                         .unwrap(),
                     UserInfo::UsernameID { username, id } => Member::builder()
                         .username(username.clone())
                         .id(*id as i64)
+                        .mr_member_type(MrMemberType::Filled)
                         .build()
                         .unwrap(),
                 })
@@ -408,6 +410,8 @@ impl ConfigProperties for Arc<ConfigFile> {
 
 #[cfg(test)]
 mod test {
+    use crate::cmds::project::MrMemberType;
+
     use super::*;
 
     fn no_env(_: &str) -> Result<String> {
@@ -496,6 +500,7 @@ mod test {
         assert_eq!(2, members.len());
         assert_eq!("jdoe", members[0].username);
         assert_eq!(1231, members[0].id);
+        assert_eq!(MrMemberType::Filled, members[0].mr_member_type);
         assert_eq!("jane", members[1].username);
         assert_eq!(1232, members[1].id);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -308,6 +308,7 @@ mod test {
         cache_location = "/home/user/.config/mr_cache"
         preferred_assignee_username = 'jordilin'
         rate_limit_remaining_threshold=15
+        merge_request_description_signature = "- devops team :-)"
 
         [gitlab_com.max_pages_api]
         merge_request = 2
@@ -339,6 +340,10 @@ mod test {
             config.cache_location().unwrap()
         );
         assert_eq!(15, config.rate_limit_remaining_threshold());
+        assert_eq!(
+            "- devops team :-)",
+            config.merge_request_description_signature()
+        );
         assert_eq!("jordilin", config.preferred_assignee_username());
         assert_eq!(2, config.get_max_pages(&ApiOperation::MergeRequest));
         assert_eq!(3, config.get_max_pages(&ApiOperation::Pipeline));
@@ -372,10 +377,7 @@ mod test {
     fn test_config_defaults() {
         let config_data = r#"
         [github_com]
-        api_token="1234"
-        cache_location="/home/user/.config/mr_cache"
-        preferred_assignee_username="jordilin"
-        merge_request_description_signature="- devops team :-)"
+        api_token = '1234'
         "#;
         let domain = "github.com";
         let reader = std::io::Cursor::new(config_data);
@@ -392,6 +394,9 @@ mod test {
             RATE_LIMIT_REMAINING_THRESHOLD,
             config.rate_limit_remaining_threshold()
         );
+        assert_eq!(None, config.cache_location());
+        assert_eq!("", config.preferred_assignee_username());
+        assert_eq!("", config.merge_request_description_signature());
     }
 
     #[test]
@@ -448,8 +453,6 @@ mod test {
     fn test_use_gitlab_com_api_token_envvar() {
         let config_data = r#"
         [gitlab_com]
-        cache_location="/home/user/.config/mr_cache"
-        rate_limit_remaining_threshold=15
         "#;
         let domain = "gitlab.com";
         let reader = std::io::Cursor::new(config_data);
@@ -462,8 +465,6 @@ mod test {
     fn test_use_sub_domain_gitlab_token_env_var() {
         let config_data = r#"
         [gitlab_company_com]
-        cache_location="/home/user/.config/mr_cache"
-        rate_limit_remaining_threshold=15
         "#;
         let domain = "gitlab.company.com";
         let reader = std::io::Cursor::new(config_data);
@@ -476,8 +477,6 @@ mod test {
     fn test_domain_without_top_level_domain_token_envvar() {
         let config_data = r#"
         [gitlabweb]
-        cache_location="/home/user/.config/mr_cache"
-        rate_limit_remaining_threshold=15
         "#;
         let domain = "gitlabweb";
         let reader = std::io::Cursor::new(config_data);

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -11,20 +11,31 @@ use crate::cmds::project::Member;
 use crate::error;
 use crate::Result;
 
+#[derive(Builder)]
 pub struct MergeRequestUserInput {
     pub title: String,
     pub description: String,
     pub user_id: i64,
     pub username: String,
+    pub assignee: Member,
 }
 
 impl MergeRequestUserInput {
+    pub fn builder() -> MergeRequestUserInputBuilder {
+        MergeRequestUserInputBuilder::default()
+    }
+
     pub fn new(title: &str, description: &str, user_id: i64, username: &str) -> Self {
         MergeRequestUserInput {
             title: title.to_string(),
             description: description.to_string(),
             user_id,
             username: username.to_string(),
+            assignee: Member::builder()
+                .id(user_id)
+                .username(username.to_string())
+                .build()
+                .unwrap(),
         }
     }
 }
@@ -56,12 +67,12 @@ pub fn prompt_user_merge_request_info(
         0
     };
 
-    Ok(MergeRequestUserInput::new(
-        &title,
-        &description,
-        members[assignee_members_index].id,
-        &members[assignee_members_index].username,
-    ))
+    Ok(MergeRequestUserInput::builder()
+        .title(title)
+        .description(description)
+        .assignee(members[assignee_members_index].clone())
+        .build()
+        .unwrap())
 }
 
 pub fn prompt_user_title_description(

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -15,8 +15,6 @@ use crate::Result;
 pub struct MergeRequestUserInput {
     pub title: String,
     pub description: String,
-    pub user_id: i64,
-    pub username: String,
     pub assignee: Member,
 }
 
@@ -29,8 +27,6 @@ impl MergeRequestUserInput {
         MergeRequestUserInput {
             title: title.to_string(),
             description: description.to_string(),
-            user_id,
-            username: username.to_string(),
             assignee: Member::builder()
                 .id(user_id)
                 .username(username.to_string())

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -147,7 +147,7 @@ pub fn show_summary_merge_request(
         Style::Bold,
     );
     show_input("Target branch", &args.target_branch, false, Style::Bold);
-    show_input("Assignee", &args.username, false, Style::Bold);
+    show_input("Assignee", &args.assignee.username, false, Style::Bold);
     show_input("Title", &args.title, false, Style::Bold);
     if !args.description.is_empty() {
         show_input("Description:", &args.description, true, Style::Bold);

--- a/src/init.rs
+++ b/src/init.rs
@@ -29,7 +29,7 @@ rate_limit_remaining_threshold=10
 [<DOMAIN>.merge_requests]
 
 preferred_assignee_username="<VALUE>"
-merge_request_description_signature=""
+description_signature=""
 
 # Array of usernames if the remote is Github
 # Array of hashmaps username => user ID if the remote is Gitlab

--- a/src/init.rs
+++ b/src/init.rs
@@ -34,11 +34,10 @@ merge_request_description_signature=""
 # Array of usernames if the remote is Github
 # Array of hashmaps username => user ID if the remote is Gitlab
 # Ex:
-# reviewers = ["user1", "user2"]
-# reviewers = [{"username": "user1", "id": "1234"}, {"username": "user2", "id": "5678"}]
+# members = ["user1", "user2"]
+# members = [{"username": "user1", "id": "1234"}, {"username": "user2", "id": "5678"}]
 
-reviewers = []
-assignees = []
+members = []
 
 [<DOMAIN>.cache_expirations]
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -18,14 +18,27 @@ const CONFIG_TEMPLATE: &str = r#"
 
 api_token="<VALUE>"
 cache_location=".cache/gitar"
-preferred_assignee_username="<VALUE>"
-merge_request_description_signature=""
+
 
 # Rate limit remaining threshold. Threshold by which the tool will stop
 # processing requests. Defaults to 10 if not provided. The remote has a counter
 # that decreases with each request. When we reach this threshold we stop for safety.
 # When it reaches 0 the remote will throw errors.
 rate_limit_remaining_threshold=10
+
+[<DOMAIN>.merge_requests]
+
+preferred_assignee_username="<VALUE>"
+merge_request_description_signature=""
+
+# Array of usernames if the remote is Github
+# Array of hashmaps username => user ID if the remote is Gitlab
+# Ex:
+# reviewers = ["user1", "user2"]
+# reviewers = [{"username": "user1", "id": "1234"}, {"username": "user2", "id": "5678"}]
+
+reviewers = []
+assignees = []
 
 [<DOMAIN>.cache_expirations]
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     http::{self, Headers, Request},
     log_info,
+    remote::RemoteURL,
     time::{self, Milliseconds, Seconds},
     Result,
 };
@@ -57,7 +58,7 @@ pub trait HttpRunner {
 #[derive(Clone, Debug)]
 pub enum CmdInfo {
     StatusModified(bool),
-    RemoteUrl { domain: String, path: String },
+    RemoteUrl(RemoteURL),
     Branch(String),
     CommitSummary(String),
     CommitMessage(String),

--- a/tests/read_config_test.rs
+++ b/tests/read_config_test.rs
@@ -1,4 +1,4 @@
-use gr::remote::read_config;
+use gr::remote::{read_config, RemoteURL};
 use std::io::Write;
 use std::path::Path;
 use tempfile::NamedTempFile;
@@ -18,8 +18,9 @@ fn test_read_config_valid() {
     cache_location="/tmp/cache"
     "#;
     let temp_file = create_temp_config_file(config_content);
-    let project_path = "/jordilin/gitar";
-    let result = read_config(temp_file.path(), "github.test.com", project_path);
+    let project_path = "/jordilin/gitar".to_string();
+    let url = RemoteURL::new("github.test.com".to_string(), project_path);
+    let result = read_config(temp_file.path(), &url);
     assert!(result.is_ok());
     let config = result.unwrap();
     assert_eq!(config.api_token(), "1234");
@@ -28,24 +29,18 @@ fn test_read_config_valid() {
 
 #[test]
 fn test_read_config_file_not_found_and_no_token_env_var_is_error() {
-    let project_path = "/jordilin/gitar";
-    let result = read_config(
-        Path::new("/non/existent/path.txt"),
-        "github.integrationtest.com",
-        project_path,
-    );
+    let project_path = "/jordilin/gitar".to_string();
+    let url = RemoteURL::new("github.integrationtest.com".to_string(), project_path);
+    let result = read_config(Path::new("/non/existent/path.txt"), &url);
     assert!(result.is_err());
 }
 
 #[test]
 fn test_read_config_file_not_found_with_token_env_var_is_ok() {
     std::env::set_var("INTEGRATIONTEST_API_TOKEN", "123");
-    let project_path = "/jordilin/gitar";
-    let config_res = read_config(
-        Path::new("/non/existent/path.txt"),
-        "integrationtest.com",
-        project_path,
-    );
+    let project_path = "/jordilin/gitar".to_string();
+    let url = RemoteURL::new("integrationtest.com".to_string(), project_path);
+    let config_res = read_config(Path::new("/non/existent/path.txt"), &url);
     assert!(config_res.is_ok());
     std::env::remove_var("INTEGRATIONTEST_API_TOKEN");
 }
@@ -53,8 +48,9 @@ fn test_read_config_file_not_found_with_token_env_var_is_ok() {
 #[test]
 fn test_read_config_empty_file() {
     let temp_file = create_temp_config_file("");
-    let project_path = "/jordilin/gitar";
-    let result = read_config(temp_file.path(), "github.com", project_path);
+    let project_path = "/jordilin/gitar".to_string();
+    let url = RemoteURL::new("github.com".to_string(), project_path);
+    let result = read_config(temp_file.path(), &url);
     assert!(result.is_err());
 }
 
@@ -65,9 +61,10 @@ fn test_read_config_invalid_data() {
     # Missing cache_location - This is still a valid config where key has no value
     github.com.cache_location
     "#;
-    let project_path = "/jordilin/gitar";
+    let project_path = "/jordilin/gitar".to_string();
     let temp_file = create_temp_config_file(config_content);
-    assert!(read_config(temp_file.path(), "github.com", project_path).is_err());
+    let url = RemoteURL::new("github.com".to_string(), project_path);
+    assert!(read_config(temp_file.path(), &url).is_err());
 }
 
 #[test]
@@ -76,8 +73,9 @@ fn test_read_config_unknown_domain() {
     github.com.api_token=1234
     github.com.cache_location=/tmp/cache
     "#;
-    let project_path = "/jordilin/gitar";
+    let project_path = "/jordilin/gitar".to_string();
     let temp_file = create_temp_config_file(config_content);
-    let result = read_config(temp_file.path(), "gitlab.com", project_path);
+    let url = RemoteURL::new("gitlab.com".to_string(), project_path);
+    let result = read_config(temp_file.path(), &url);
     assert!(result.is_err());
 }


### PR DESCRIPTION
Provide merge request configuration and optional preferred default assignee.

The configuration adds a new section as follows:

```toml
[<DOMAIN>.merge_requests]

preferred_assignee_username="<VALUE>"
description_signature=""

# Array of usernames if the remote is Github
# Array of hashmaps username => user ID if the remote is Gitlab
# Ex:
# members = ["user1", "user2"]
# members = [{"username": "user1", "id": "1234"}, {"username": "user2", "id": "5678"}]

members = []
```

Merge requests members list can be overriden on a per project basis.
For example, one could do:

```toml
[github_com.jordilin_gitar.merge_requests]
members = ["user2"]
```

while still maintaining a default `members` list for the full remote.

This way, `gitar` does not have to pull all users from a project when opening a
new merge request for assignee prompting. Some remotes like Gitlab can add
large lists of users coming from groups to a specific project, but clients
still might want to keep a list short. The downside of this is that we need to
pull user IDs up front in case the remote is Gitlab. For Github, a list of
usernames is enough. The reason for that is the REST APIs. Gitlab requires
user IDs and Github just usernames.
