### PR TITLE
Impl --format toml

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -107,6 +107,7 @@ pub enum FormatCli {
     Csv,
     Json,
     Pipe,
+    Toml,
 }
 
 impl Display for FormatCli {
@@ -115,6 +116,7 @@ impl Display for FormatCli {
             FormatCli::Csv => write!(f, "csv"),
             FormatCli::Pipe => write!(f, "pipe"),
             FormatCli::Json => write!(f, "json"),
+            FormatCli::Toml => write!(f, "toml"),
         }
     }
 }
@@ -187,6 +189,7 @@ impl From<FormatCli> for Format {
             FormatCli::Csv => Format::CSV,
             FormatCli::Json => Format::JSON,
             FormatCli::Pipe => Format::PIPE,
+            FormatCli::Toml => Format::TOML,
         }
     }
 }

--- a/src/cmds/project.rs
+++ b/src/cmds/project.rs
@@ -129,7 +129,12 @@ impl From<Member> for DisplayBody {
         DisplayBody {
             columns: vec![
                 Column::new("ID", m.id.to_string()),
-                Column::new("Name", m.name),
+                Column::builder()
+                    .name("Name".to_string())
+                    .value(m.name)
+                    .optional(true)
+                    .build()
+                    .unwrap(),
                 Column::new("Username", m.username),
             ],
         }
@@ -404,7 +409,7 @@ mod test {
             Ok(vec![Member::builder()
                 .id(1)
                 .name("Tom".to_string())
-                .username("Sawyer".to_string())
+                .username("tomsawyer".to_string())
                 .build()
                 .unwrap()])
         }
@@ -571,7 +576,7 @@ mod test {
             .unwrap();
         list_project_members(remote, body_args, cli_args, &mut writer).unwrap();
         assert_eq!(
-            "ID|Name|Username\n1|Tom|Sawyer\n",
+            "ID|Username\n1|tomsawyer\n",
             String::from_utf8(writer).unwrap()
         );
     }

--- a/src/cmds/user.rs
+++ b/src/cmds/user.rs
@@ -90,7 +90,7 @@ mod tests {
         let mut writer = Vec::new();
         get_user_details(Arc::new(remote), &args, &mut writer).unwrap();
         assert_eq!(
-            "ID|Name|Username\n1||tomsawyer\n",
+            "ID|Username\n1|tomsawyer\n",
             String::from_utf8(writer).unwrap()
         );
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -68,7 +68,7 @@ pub fn print<W: Write, D: Into<DisplayBody> + Clone>(
                     .columns
                     .into_iter()
                     .filter(|c| !c.optional || args.display_optional)
-                    .map(|item| (item.name, item.value))
+                    .map(|item| (item.name.to_lowercase(), item.value))
                     .collect();
                 writeln!(w, "{}", serde_json::to_string(&kvs)?)?;
             }


### PR DESCRIPTION
Provide --format toml and lowercase keys for both json and toml.
This will allow to format project members in toml so it is compatible with
gitar merge requests configuration.
