### PR TITLE
Fix: Propagate assignee type to client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "git-ar"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-ar"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 license = "MIT"

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -660,20 +660,16 @@ fn cmds<R: BufRead + Send + Sync + 'static>(
     let remote_cl = remote.clone();
     let remote_project_cmd = move || -> Result<CmdInfo> { remote_cl.get_project_data(None, None) };
     let assignees_cmd = move || -> Result<CmdInfo> {
-        let assignees = config.merge_request_members();
-        if assignees.is_some() {
-            let mut assignees = assignees.unwrap();
-            let default_assignee = config.preferred_assignee_username();
-            if let Some(assignee) = default_assignee {
-                assignees.insert(0, assignee);
-                // Allow client to unselect the default assignee
-                assignees.insert(1, Member::default());
-            } else {
-                assignees.insert(0, Member::default());
-            }
-            return Ok(CmdInfo::Members(assignees));
+        let mut assignees = config.merge_request_members();
+        let default_assignee = config.preferred_assignee_username();
+        if let Some(assignee) = default_assignee {
+            assignees.insert(0, assignee);
+            // Allow client to unselect the default assignee
+            assignees.insert(1, Member::default());
+        } else {
+            assignees.insert(0, Member::default());
         }
-        Ok(CmdInfo::Members(vec![]))
+        return Ok(CmdInfo::Members(assignees));
     };
     let status_runner = task_runner.clone();
     let git_status_cmd = || -> Result<CmdInfo> { git::status(status_runner) };

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -669,7 +669,7 @@ fn cmds<R: BufRead + Send + Sync + 'static>(
         } else {
             assignees.insert(0, Member::default());
         }
-        return Ok(CmdInfo::Members(assignees));
+        Ok(CmdInfo::Members(assignees))
     };
     let status_runner = task_runner.clone();
     let git_status_cmd = || -> Result<CmdInfo> { git::status(status_runner) };


### PR DESCRIPTION
Simplify logic by setting merge request members to an empty array if not
provided.