### PR TITLE
Override URL with mr --target-repo

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,7 +151,7 @@ pub enum CliOptions {
     User(UserOptions),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct CliArgs {
     pub verbose: u8,
     pub repo: Option<String>,

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -1,6 +1,5 @@
 use crate::api_traits::{CommentMergeRequest, MergeRequest, RemoteProject, Timestamp};
 use crate::cli::merge_request::MergeRequestOptions;
-use crate::cli::CliArgs;
 use crate::config::ConfigProperties;
 use crate::display::{Column, DisplayBody};
 use crate::error::{AddContext, GRError};
@@ -335,19 +334,12 @@ impl From<Comment> for DisplayBody {
 
 pub fn execute(
     options: MergeRequestOptions,
-    global_args: CliArgs,
     config: Arc<dyn ConfigProperties>,
     domain: String,
     path: String,
 ) -> Result<()> {
     match options {
         MergeRequestOptions::Create(cli_args) => {
-            if global_args.repo.is_some() {
-                return Err(GRError::PreconditionNotMet(
-                    "--repo not allowed when creating a merge request".to_string(),
-                )
-                .into());
-            }
             let mr_remote = remote::get_mr(
                 domain.clone(),
                 path.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,13 +53,12 @@ fn handle_cli_options(
                 // we are targetting is either our own or the remote of our
                 // fork specified with --target-repo
                 let reqs = vec![CliDomainRequirements::CdInLocalRepo];
-                let url = remote::url(
+                remote::url(
                     &cli_args,
                     &reqs,
                     &BlockingCommand,
                     &opts.target_repo.as_deref(),
-                )?;
-                url
+                )?
             } else {
                 // For operations involving list, get, close, etc... it is not a
                 // requirement to be in a local repo. We can do --repo <repo> to
@@ -68,8 +67,7 @@ fn handle_cli_options(
                     CliDomainRequirements::RepoArgs,
                     CliDomainRequirements::CdInLocalRepo,
                 ];
-                let url = remote::url(&cli_args, &reqs, &BlockingCommand, &None)?;
-                url
+                remote::url(&cli_args, &reqs, &BlockingCommand, &None)?
             };
 
             let config = remote::read_config(&config_file, &url)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@ use std::{path::Path, sync::Arc};
 
 use env_logger::Env;
 use gr::{
-    cli::{browse::BrowseOptions, parse_cli, trending::TrendingOptions, CliOptions},
+    cli::{
+        browse::BrowseOptions, merge_request::MergeRequestOptions, parse_cli,
+        trending::TrendingOptions, CliOptions,
+    },
     cmds::{self, browse, cicd, docker, merge_request, project},
     init,
     remote::{self, CliDomainRequirements, RemoteURL},
@@ -45,15 +48,33 @@ fn handle_cli_options(
 ) -> Result<()> {
     match cli_options {
         CliOptions::MergeRequest(options) => {
-            let requirements = vec![
-                CliDomainRequirements::RepoArgs,
-                CliDomainRequirements::CdInLocalRepo,
-            ];
-            let url = remote::url(&cli_args, &requirements, &BlockingCommand)?;
+            let url = if let MergeRequestOptions::Create(opts) = &options {
+                // This is a create merge request operation. The remote URL that
+                // we are targetting is either our own or the remote of our
+                // fork specified with --target-repo
+                let reqs = vec![CliDomainRequirements::CdInLocalRepo];
+                let url = remote::url(
+                    &cli_args,
+                    &reqs,
+                    &BlockingCommand,
+                    &opts.target_repo.as_deref(),
+                )?;
+                url
+            } else {
+                // For operations involving list, get, close, etc... it is not a
+                // requirement to be in a local repo. We can do --repo <repo> to
+                // list merge requests, close merge requests, etc.
+                let reqs = vec![
+                    CliDomainRequirements::RepoArgs,
+                    CliDomainRequirements::CdInLocalRepo,
+                ];
+                let url = remote::url(&cli_args, &reqs, &BlockingCommand, &None)?;
+                url
+            };
+
             let config = remote::read_config(&config_file, &url)?;
             merge_request::execute(
                 options,
-                cli_args,
                 config,
                 url.domain().to_string(),
                 url.path().to_string(),
@@ -66,7 +87,7 @@ fn handle_cli_options(
                 CliDomainRequirements::RepoArgs,
                 CliDomainRequirements::CdInLocalRepo,
             ];
-            let url = remote::url(&cli_args, &requirements, &BlockingCommand)?;
+            let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
             browse::execute(
                 options,
                 config,
@@ -79,7 +100,7 @@ fn handle_cli_options(
                 CliDomainRequirements::RepoArgs,
                 CliDomainRequirements::CdInLocalRepo,
             ];
-            let url = remote::url(&cli_args, &requirements, &BlockingCommand)?;
+            let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
             let config = remote::read_config(&config_file, &url)?;
             cicd::execute(
                 options,
@@ -93,7 +114,7 @@ fn handle_cli_options(
                 CliDomainRequirements::RepoArgs,
                 CliDomainRequirements::CdInLocalRepo,
             ];
-            let url = remote::url(&cli_args, &requirements, &BlockingCommand)?;
+            let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
             let config = remote::read_config(&config_file, &url)?;
             project::execute(
                 options,
@@ -107,7 +128,7 @@ fn handle_cli_options(
                 CliDomainRequirements::RepoArgs,
                 CliDomainRequirements::CdInLocalRepo,
             ];
-            let url = remote::url(&cli_args, &requirements, &BlockingCommand)?;
+            let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
             let config = remote::read_config(&config_file, &url)?;
             docker::execute(
                 options,
@@ -121,7 +142,7 @@ fn handle_cli_options(
                 CliDomainRequirements::RepoArgs,
                 CliDomainRequirements::CdInLocalRepo,
             ];
-            let url = remote::url(&cli_args, &requirements, &BlockingCommand)?;
+            let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
             let config = remote::read_config(&config_file, &url)?;
             cmds::release::execute(
                 options,
@@ -135,7 +156,7 @@ fn handle_cli_options(
                 CliDomainRequirements::DomainArgs,
                 CliDomainRequirements::CdInLocalRepo,
             ];
-            let url = remote::url(&cli_args, &requirements, &BlockingCommand)?;
+            let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
             let config = remote::read_config(&config_file, &url)?;
             cmds::my::execute(
                 options,
@@ -161,7 +182,7 @@ fn handle_cli_options(
                 CliDomainRequirements::RepoArgs,
                 CliDomainRequirements::CdInLocalRepo,
             ];
-            let url = remote::url(&cli_args, &requirements, &BlockingCommand)?;
+            let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
             let config = remote::read_config(&config_file, &url)?;
             cmds::cache::execute(options, config)
         }
@@ -178,7 +199,7 @@ fn handle_cli_options(
                 CliDomainRequirements::RepoArgs,
                 CliDomainRequirements::CdInLocalRepo,
             ];
-            let url = remote::url(&cli_args, &requirements, &BlockingCommand)?;
+            let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
             let config = remote::read_config(&config_file, &url)?;
             cmds::user::execute(
                 options,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -442,7 +442,7 @@ pub enum CliDomainRequirements {
     RepoArgs,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct RemoteURL {
     /// Domain of the project. Ex github.com
     domain: String,
@@ -538,6 +538,7 @@ pub fn url<R: TaskRunner<Response = Response>>(
     cli_args: &cli::CliArgs,
     requirements: &[CliDomainRequirements],
     runner: &R,
+    target_repo: &Option<&str>,
 ) -> Result<RemoteURL> {
     let mut errors = Vec::new();
     for requirement in requirements {
@@ -954,7 +955,7 @@ mod test {
             .unwrap();
         let runner = MockRunner::new(vec![response]);
         let requirements = vec![CliDomainRequirements::CdInLocalRepo];
-        let url = url(&cli_args, &requirements, &runner).unwrap();
+        let url = url(&cli_args, &requirements, &runner, &None).unwrap();
         assert_eq!("github.com", url.domain());
         assert_eq!("jordilin/gitar", url.path());
     }
@@ -965,7 +966,7 @@ mod test {
         let response = Response::builder().body("".to_string()).build().unwrap();
         let runner = MockRunner::new(vec![response]);
         let requirements = vec![CliDomainRequirements::CdInLocalRepo];
-        let result = url(&cli_args, &requirements, &runner);
+        let result = url(&cli_args, &requirements, &runner, &None);
         match result {
             Err(err) => match err.downcast_ref::<error::GRError>() {
                 Some(error::GRError::PreconditionNotMet(_)) => (),
@@ -983,7 +984,13 @@ mod test {
             CliDomainRequirements::RepoArgs,
         ];
         let response = Response::builder().body("".to_string()).build().unwrap();
-        let url = url(&cli_args, &requirements, &MockRunner::new(vec![response])).unwrap();
+        let url = url(
+            &cli_args,
+            &requirements,
+            &MockRunner::new(vec![response]),
+            &None,
+        )
+        .unwrap();
         assert_eq!("github.com", url.domain());
         assert_eq!("jordilin/gitar", url.path());
         assert_eq!("jordilin_gitar", url.config_encoded_project_path());
@@ -997,7 +1004,13 @@ mod test {
             CliDomainRequirements::DomainArgs,
         ];
         let response = Response::builder().body("".to_string()).build().unwrap();
-        let url = url(&cli_args, &requirements, &MockRunner::new(vec![response])).unwrap();
+        let url = url(
+            &cli_args,
+            &requirements,
+            &MockRunner::new(vec![response]),
+            &None,
+        )
+        .unwrap();
         assert_eq!("github.com", url.domain());
         assert_eq!("", url.path());
     }


### PR DESCRIPTION
Allows for merge request configuration of the target repository URL.