### PR TITLE
Support different configuration files

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,7 +65,7 @@ struct Args {
     /// Bypass local .git/config. Use domain. Ex. for my subcommands
     #[clap(long, global = true, value_name = "DOMAIN")]
     pub domain: Option<String>,
-    /// Full path to the config location. Default is $HOME/.config/gitar/api
+    /// Full path to the config location. Default is $HOME/.config/gitar
     #[clap(long, global = true, value_name = "PATH")]
     pub config: Option<String>,
 }

--- a/src/cmds/amps.rs
+++ b/src/cmds/amps.rs
@@ -5,13 +5,14 @@ use crate::{
     dialog,
     error::GRError,
     io::{Response, TaskRunner},
+    remote::ConfigFilePath,
     shell, Result,
 };
 
-pub fn execute(options: AmpsOptions, config_file: std::path::PathBuf) -> Result<()> {
+pub fn execute(options: AmpsOptions, config_file: ConfigFilePath) -> Result<()> {
     match options {
         Exec(amp_name_args) => {
-            let base_path = config_file.parent().unwrap();
+            let base_path = config_file.directory();
             let amps_scripts = base_path.join("amps");
             if amp_name_args.is_empty() {
                 let runner = shell::BlockingCommand;
@@ -31,7 +32,7 @@ pub fn execute(options: AmpsOptions, config_file: std::path::PathBuf) -> Result<
             Ok(())
         }
         _ => {
-            let base_path = config_file.parent().unwrap();
+            let base_path = config_file.directory();
             let amps_scripts = base_path.join("amps");
             let runner = shell::BlockingCommand;
             let amps = list_amps(runner, amps_scripts.to_str().unwrap())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 pub mod api_defaults;
 pub mod api_traits;
 pub mod cache;
@@ -42,3 +44,14 @@ fn json_loads(data: &str) -> Result<serde_json::Value> {
 }
 
 pub const USER_GUIDE_URL: &str = "https://jordilin.github.io/gitar";
+
+lazy_static! {
+    pub static ref DEFAULT_CONFIG_PATH: PathBuf = {
+        let home = std::env::var("HOME").unwrap();
+        PathBuf::from(home).join(".config/gitar")
+    };
+}
+
+pub fn get_default_config_path() -> &'static PathBuf {
+    &DEFAULT_CONFIG_PATH
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ fn main() -> Result<()> {
         std::process::exit(1);
     });
     let cli_args = option_args.cli_args;
+    // Default config file gitar.toml
     let mut config_file = get_default_config_path().join("gitar.toml");
     if let Some(ref config) = cli_args.config {
         config_file = Path::new(&config).to_path_buf();
@@ -67,7 +68,7 @@ fn handle_cli_options(
                 remote::url(&cli_args, &reqs, &BlockingCommand, &None)?
             };
 
-            let config = remote::read_config(&config_file, &url)?;
+            let config = remote::read_config(&cli_args, &url)?;
             merge_request::execute(
                 options,
                 config,
@@ -96,7 +97,7 @@ fn handle_cli_options(
                 CliDomainRequirements::CdInLocalRepo,
             ];
             let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
-            let config = remote::read_config(&config_file, &url)?;
+            let config = remote::read_config(&cli_args, &url)?;
             cicd::execute(
                 options,
                 config,
@@ -110,7 +111,7 @@ fn handle_cli_options(
                 CliDomainRequirements::CdInLocalRepo,
             ];
             let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
-            let config = remote::read_config(&config_file, &url)?;
+            let config = remote::read_config(&cli_args, &url)?;
             project::execute(
                 options,
                 config,
@@ -124,7 +125,7 @@ fn handle_cli_options(
                 CliDomainRequirements::CdInLocalRepo,
             ];
             let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
-            let config = remote::read_config(&config_file, &url)?;
+            let config = remote::read_config(&cli_args, &url)?;
             docker::execute(
                 options,
                 config,
@@ -138,7 +139,7 @@ fn handle_cli_options(
                 CliDomainRequirements::CdInLocalRepo,
             ];
             let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
-            let config = remote::read_config(&config_file, &url)?;
+            let config = remote::read_config(&cli_args, &url)?;
             cmds::release::execute(
                 options,
                 config,
@@ -152,7 +153,7 @@ fn handle_cli_options(
                 CliDomainRequirements::CdInLocalRepo,
             ];
             let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
-            let config = remote::read_config(&config_file, &url)?;
+            let config = remote::read_config(&cli_args, &url)?;
             cmds::my::execute(
                 options,
                 config,
@@ -166,7 +167,7 @@ fn handle_cli_options(
                 // <language>` everywhere in the shell.
                 let domain = "github.com";
                 let url = RemoteURL::new(domain.to_string(), "".to_string());
-                let config = remote::read_config(&config_file, &url)?;
+                let config = remote::read_config(&cli_args, &url)?;
                 cmds::trending::execute(args, config, domain)
             }
         },
@@ -178,7 +179,7 @@ fn handle_cli_options(
                 CliDomainRequirements::CdInLocalRepo,
             ];
             let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
-            let config = remote::read_config(&config_file, &url)?;
+            let config = remote::read_config(&cli_args, &url)?;
             cmds::cache::execute(options, config)
         }
         CliOptions::Manual => browse::execute(
@@ -195,7 +196,7 @@ fn handle_cli_options(
                 CliDomainRequirements::CdInLocalRepo,
             ];
             let url = remote::url(&cli_args, &requirements, &BlockingCommand, &None)?;
-            let config = remote::read_config(&config_file, &url)?;
+            let config = remote::read_config(&cli_args, &url)?;
             cmds::user::execute(
                 options,
                 config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 
 use env_logger::Env;
 use gr::{
@@ -7,7 +7,7 @@ use gr::{
         trending::TrendingOptions, CliOptions,
     },
     cmds::{self, browse, cicd, docker, merge_request, project},
-    get_default_config_path, init,
+    init,
     remote::{self, CliDomainRequirements, ConfigFilePath, RemoteURL},
     shell::BlockingCommand,
     Result,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,23 +7,20 @@ use gr::{
         trending::TrendingOptions, CliOptions,
     },
     cmds::{self, browse, cicd, docker, merge_request, project},
-    init,
+    get_default_config_path, init,
     remote::{self, CliDomainRequirements, RemoteURL},
     shell::BlockingCommand,
     Result,
 };
 
-const DEFAULT_CONFIG_PATH: &str = ".config/gitar/gitar.toml";
-
 fn main() -> Result<()> {
-    let home_dir = std::env::var("HOME").unwrap();
     let option_args = parse_cli();
     let cli_options = option_args.cli_options.unwrap_or_else(|| {
         eprintln!("Please specify a subcommand");
         std::process::exit(1);
     });
     let cli_args = option_args.cli_args;
-    let mut config_file = Path::new(&home_dir).join(DEFAULT_CONFIG_PATH);
+    let mut config_file = get_default_config_path().join("gitar.toml");
     if let Some(ref config) = cli_args.config {
         config_file = Path::new(&config).to_path_buf();
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -622,8 +622,6 @@ pub fn read_config(
         url.config_encoded_project_path()
     ));
 
-    println!("config_path: {:?}", config_path.file_name);
-
     log_debug!("config_file: {:?}", config_path.file_name);
     log_debug!("domain_config_file: {:?}", domain_config_file);
     log_debug!("domain_project_file: {:?}", domain_project_file);

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -624,7 +624,7 @@ pub fn read_config(
 
     log_debug!("config_file: {:?}", config_path.file_name);
     log_debug!("domain_config_file: {:?}", domain_config_file);
-    log_debug!("domain_project_file: {:?}", domain_project_file);
+    log_debug!("domain_project_config_file: {:?}", domain_project_file);
 
     let mut extra_configs = [domain_config_file, domain_project_file]
         .into_iter()

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -15,7 +15,7 @@ use crate::github::Github;
 use crate::gitlab::Gitlab;
 use crate::io::{CmdInfo, HttpRunner, Response, TaskRunner};
 use crate::time::Milliseconds;
-use crate::{cli, error, http, log_debug, log_info};
+use crate::{cli, error, get_default_config_path, http, log_debug, log_info};
 use crate::{git, Result};
 use std::sync::Arc;
 
@@ -614,13 +614,22 @@ pub fn read_config<P: AsRef<Path>>(
     url: &RemoteURL,
 ) -> Result<Arc<dyn ConfigProperties>> {
     let enc_domain = url.config_encoded_domain();
-    let mut extra_configs = [
-        format!("{}.toml", enc_domain),
-        format!("{}_{}.toml", enc_domain, url.config_encoded_project_path()),
-    ]
-    .into_iter()
-    .map(PathBuf::from)
-    .collect::<Vec<PathBuf>>();
+
+    let domain_config_file = get_default_config_path().join(format!("{}.toml", enc_domain));
+    let domain_project_file = get_default_config_path().join(format!(
+        "{}_{}.toml",
+        enc_domain,
+        url.config_encoded_project_path()
+    ));
+
+    log_debug!("config_file: {:?}", config_file.as_ref());
+    log_debug!("domain_config_file: {:?}", domain_config_file);
+    log_debug!("domain_project_file: {:?}", domain_project_file);
+
+    let mut extra_configs = [domain_config_file, domain_project_file]
+        .into_iter()
+        .map(PathBuf::from)
+        .collect::<Vec<PathBuf>>();
 
     fn open_files(file_paths: &[PathBuf]) -> Vec<File> {
         file_paths

--- a/tests/fixtures/configs/invalid_domain/gitar.toml
+++ b/tests/fixtures/configs/invalid_domain/gitar.toml
@@ -1,0 +1,3 @@
+[ non_existent_domain ]
+api_token="1234"
+cache_location="/tmp/cache"

--- a/tests/fixtures/configs/invalid_toml/gitar.toml
+++ b/tests/fixtures/configs/invalid_toml/gitar.toml
@@ -1,0 +1,2 @@
+github.com.api_token=1234
+github.com.cache_location=/tmp/cache

--- a/tests/fixtures/configs/ok/gitar.toml
+++ b/tests/fixtures/configs/ok/gitar.toml
@@ -1,0 +1,3 @@
+[github_test_com]
+api_token="1234"
+cache_location="/tmp/cache"

--- a/tests/read_config_test.rs
+++ b/tests/read_config_test.rs
@@ -20,7 +20,7 @@ fn test_read_config_valid() {
     let temp_file = create_temp_config_file(config_content);
     let project_path = "/jordilin/gitar".to_string();
     let url = RemoteURL::new("github.test.com".to_string(), project_path);
-    let result = read_config(temp_file.path(), &url);
+    let result = read_config(&temp_file, &url);
     assert!(result.is_ok());
     let config = result.unwrap();
     assert_eq!(config.api_token(), "1234");
@@ -31,7 +31,7 @@ fn test_read_config_valid() {
 fn test_read_config_file_not_found_and_no_token_env_var_is_error() {
     let project_path = "/jordilin/gitar".to_string();
     let url = RemoteURL::new("github.integrationtest.com".to_string(), project_path);
-    let result = read_config(Path::new("/non/existent/path.txt"), &url);
+    let result = read_config(&Path::new("/non/existent/path.txt"), &url);
     assert!(result.is_err());
 }
 
@@ -40,7 +40,7 @@ fn test_read_config_file_not_found_with_token_env_var_is_ok() {
     std::env::set_var("INTEGRATIONTEST_API_TOKEN", "123");
     let project_path = "/jordilin/gitar".to_string();
     let url = RemoteURL::new("integrationtest.com".to_string(), project_path);
-    let config_res = read_config(Path::new("/non/existent/path.txt"), &url);
+    let config_res = read_config(&Path::new("/non/existent/path.txt"), &url);
     assert!(config_res.is_ok());
     std::env::remove_var("INTEGRATIONTEST_API_TOKEN");
 }
@@ -50,7 +50,7 @@ fn test_read_config_empty_file() {
     let temp_file = create_temp_config_file("");
     let project_path = "/jordilin/gitar".to_string();
     let url = RemoteURL::new("github.com".to_string(), project_path);
-    let result = read_config(temp_file.path(), &url);
+    let result = read_config(&temp_file, &url);
     assert!(result.is_err());
 }
 
@@ -64,7 +64,7 @@ fn test_read_config_invalid_data() {
     let project_path = "/jordilin/gitar".to_string();
     let temp_file = create_temp_config_file(config_content);
     let url = RemoteURL::new("github.com".to_string(), project_path);
-    assert!(read_config(temp_file.path(), &url).is_err());
+    assert!(read_config(&temp_file, &url).is_err());
 }
 
 #[test]
@@ -76,6 +76,6 @@ fn test_read_config_unknown_domain() {
     let project_path = "/jordilin/gitar".to_string();
     let temp_file = create_temp_config_file(config_content);
     let url = RemoteURL::new("gitlab.com".to_string(), project_path);
-    let result = read_config(temp_file.path(), &url);
+    let result = read_config(&temp_file, &url);
     assert!(result.is_err());
 }

--- a/tests/read_config_test.rs
+++ b/tests/read_config_test.rs
@@ -1,26 +1,18 @@
-use gr::remote::{read_config, RemoteURL};
-use std::io::Write;
-use std::path::Path;
-use tempfile::NamedTempFile;
-
-fn create_temp_config_file(content: &str) -> NamedTempFile {
-    let mut temp_file = NamedTempFile::new().unwrap();
-    write!(temp_file, "{}", content).unwrap();
-    temp_file.flush().unwrap();
-    temp_file
-}
+use gr::cli::CliArgs;
+use gr::remote::{read_config, ConfigFilePath, RemoteURL};
 
 #[test]
 fn test_read_config_valid() {
-    let config_content = r#"
-    [github_test_com]
-    api_token="1234"
-    cache_location="/tmp/cache"
-    "#;
-    let temp_file = create_temp_config_file(config_content);
     let project_path = "/jordilin/gitar".to_string();
     let url = RemoteURL::new("github.test.com".to_string(), project_path);
-    let result = read_config(&temp_file, &url);
+    let cli_args = CliArgs::new(
+        0,
+        None,
+        None,
+        Some("./tests/fixtures/configs/ok".to_string()),
+    );
+    let config_path = ConfigFilePath::new(&cli_args);
+    let result = read_config(config_path, &url);
     assert!(result.is_ok());
     let config = result.unwrap();
     assert_eq!(config.api_token(), "1234");
@@ -31,7 +23,9 @@ fn test_read_config_valid() {
 fn test_read_config_file_not_found_and_no_token_env_var_is_error() {
     let project_path = "/jordilin/gitar".to_string();
     let url = RemoteURL::new("github.integrationtest.com".to_string(), project_path);
-    let result = read_config(&Path::new("/non/existent/path.txt"), &url);
+    let cli_args = CliArgs::new(0, None, None, Some("/path/does/not/exist".to_string()));
+    let config_path = ConfigFilePath::new(&cli_args);
+    let result = read_config(config_path, &url);
     assert!(result.is_err());
 }
 
@@ -40,42 +34,53 @@ fn test_read_config_file_not_found_with_token_env_var_is_ok() {
     std::env::set_var("INTEGRATIONTEST_API_TOKEN", "123");
     let project_path = "/jordilin/gitar".to_string();
     let url = RemoteURL::new("integrationtest.com".to_string(), project_path);
-    let config_res = read_config(&Path::new("/non/existent/path.txt"), &url);
+    let cli_args = CliArgs::new(0, None, None, Some("/path/does/not/exist".to_string()));
+    let config_path = ConfigFilePath::new(&cli_args);
+    let config_res = read_config(config_path, &url);
     assert!(config_res.is_ok());
     std::env::remove_var("INTEGRATIONTEST_API_TOKEN");
 }
 
 #[test]
 fn test_read_config_empty_file() {
-    let temp_file = create_temp_config_file("");
     let project_path = "/jordilin/gitar".to_string();
     let url = RemoteURL::new("github.com".to_string(), project_path);
-    let result = read_config(&temp_file, &url);
+    let cli_args = CliArgs::new(
+        0,
+        None,
+        None,
+        Some("./tests/fixtures/configs/ok_empty".to_string()),
+    );
+    let config_path = ConfigFilePath::new(&cli_args);
+    let result = read_config(config_path, &url);
     assert!(result.is_err());
 }
 
 #[test]
-fn test_read_config_invalid_data() {
-    let config_content = r#"
-    github.com.api_token=1234
-    # Missing cache_location - This is still a valid config where key has no value
-    github.com.cache_location
-    "#;
+fn test_read_config_invalid_toml_data() {
     let project_path = "/jordilin/gitar".to_string();
-    let temp_file = create_temp_config_file(config_content);
+    let cli_args = CliArgs::new(
+        0,
+        None,
+        None,
+        Some("./tests/fixtures/configs/invalid_toml".to_string()),
+    );
+    let config_path = ConfigFilePath::new(&cli_args);
     let url = RemoteURL::new("github.com".to_string(), project_path);
-    assert!(read_config(&temp_file, &url).is_err());
+    assert!(read_config(config_path, &url).is_err());
 }
 
 #[test]
 fn test_read_config_unknown_domain() {
-    let config_content = r#"
-    github.com.api_token=1234
-    github.com.cache_location=/tmp/cache
-    "#;
     let project_path = "/jordilin/gitar".to_string();
-    let temp_file = create_temp_config_file(config_content);
     let url = RemoteURL::new("gitlab.com".to_string(), project_path);
-    let result = read_config(&temp_file, &url);
+    let cli_args = CliArgs::new(
+        0,
+        None,
+        None,
+        Some("./tests/fixtures/configs/invalid_domain".to_string()),
+    );
+    let config_path = ConfigFilePath::new(&cli_args);
+    let result = read_config(config_path, &url);
     assert!(result.is_err());
 }


### PR DESCRIPTION
- gitar.toml
- `<domain>.toml`
- `<domain_group_projectname>.toml`

This will allow to keep configuration files smaller when project
specific configurations are provided. For example, merge request members
for each project, etc...