### PR TITLE
HTTP Backoff strategy improvements

### DIFF
--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -67,6 +67,7 @@ impl<'a, R: HttpRunner<Response = Response>> Backoff<'a, R> {
                         self.max_retries
                     );
                     if let Some(headers) = self.should_retry_on_error(&err) {
+                        // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
                         self.rate_limit_header = headers;
                         self.num_retries += 1;
                         if self.num_retries <= self.max_retries {
@@ -108,7 +109,7 @@ pub struct Exponential;
 
 impl BackOffStrategy for Exponential {
     fn wait_time(&self, base_wait: Seconds, num_retries: u32) -> Seconds {
-        // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
+        log_info!("Exponential backoff strategy");
         let wait_time = base_wait + 2u64.pow(num_retries).into();
         log_info!("Waiting for {} seconds", wait_time);
         wait_time

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,5 +1,5 @@
 use crate::api_traits::ApiOperation;
-use crate::backoff::Backoff;
+use crate::backoff::{Backoff, Exponential};
 use crate::cache::{Cache, CacheState};
 use crate::config::ConfigProperties;
 use crate::error::GRError;
@@ -384,6 +384,7 @@ impl<'a, R, T> Paginator<'a, R, T> {
                 backoff_max_retries,
                 backoff_default_wait_time,
                 time::now_epoch_seconds,
+                Box::new(Exponential),
             ),
         }
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,5 +1,5 @@
 use crate::api_traits::ApiOperation;
-use crate::backoff::ExponentialBackoff;
+use crate::backoff::Backoff;
 use crate::cache::{Cache, CacheState};
 use crate::config::ConfigProperties;
 use crate::error::GRError;
@@ -359,7 +359,7 @@ pub struct Paginator<'a, R, T> {
     iter: u32,
     throttle_time: Option<Milliseconds>,
     throttle_range: Option<(Milliseconds, Milliseconds)>,
-    backoff: ExponentialBackoff<'a, R>,
+    backoff: Backoff<'a, R>,
 }
 
 impl<'a, R, T> Paginator<'a, R, T> {
@@ -379,7 +379,7 @@ impl<'a, R, T> Paginator<'a, R, T> {
             iter: 0,
             throttle_time,
             throttle_range,
-            backoff: ExponentialBackoff::new(
+            backoff: Backoff::new(
                 runner,
                 backoff_max_retries,
                 backoff_default_wait_time,

--- a/src/test.rs
+++ b/src/test.rs
@@ -151,6 +151,10 @@ pub mod utils {
                     let headers = response.get_ratelimit_headers().unwrap_or_default();
                     return Err(error::GRError::RateLimitExceeded(headers).into());
                 }
+                500..=599 => return Err(error::GRError::RemoteServerError(response.body).into()),
+                // Just for testing purposes, if the test client sets a status
+                // code of -1 we return a HTTP transport error.
+                -1 => return Err(error::GRError::HttpTransportError(response.body).into()),
                 _ => return Err(error::gen(&response.body)),
             }
         }


### PR DESCRIPTION
- Check rate limit headers on rate limit error
- Inject backoff strategy - defaults to exponential for now