### PR TITLE
Implement auto throttling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ result
 contracts/__pycache__
 lcov.info
 /doc/book
+.description

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git-ar"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-ar"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 
 license = "MIT"

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -5,6 +5,7 @@
   - [Installation](./installation.md)
   - [Configuration](./configuration.md)
   - [Caching](./caching.md)
+  - [Listing data](./listing.md)
 - [Gitar commands](./cmds/index.md)
   - [Merge requests](./cmds/merge_request.md)
   - [Pipelines](./cmds/pipeline.md)

--- a/doc/src/getting_started.md
+++ b/doc/src/getting_started.md
@@ -5,3 +5,5 @@ a configuration file. Let's get started:
 
 - [Installation](./installation.md)
 - [Configuration](./configuration.md)
+- [Caching](./caching.md)
+- [Listing data](./listing.md)

--- a/doc/src/listing.md
+++ b/doc/src/listing.md
@@ -1,0 +1,21 @@
+# The list subcommand
+
+<!-- toc -->
+
+The list subcommand is used to pull data from specific resources such as
+pipelines and merge requests. Gitar implements best practices to avoid being
+rate limited, caches responses and uses pagination to pull the required data
+using the `--from-page` and `--to-page` flags.
+
+## Auto throttling
+
+Gitar will automatically throttle the requests after three consecutive HTTP
+calls have been made. The throttling is based on the rate limit headers plus a
+jitter interval between 1 and 5 seconds. The user can also specify a fixed
+throttle interval with `--throttle` or a random one with `--throttle-range`.
+
+## Max pages to fetch
+
+If no configuration is provided, the default is a max of 10 pages. This can be
+overriden with `--to-page` where it will fetch up to the specified page or a
+range of pages with `--from-page` and `--to-page`.

--- a/src/api_defaults.rs
+++ b/src/api_defaults.rs
@@ -18,3 +18,10 @@ pub const DEFAULT_NUMBER_REQUESTS_MINUTE: u32 = 80;
 pub const DEFAULT_PER_PAGE: u32 = 30;
 
 pub const EXPIRE_IMMEDIATELY: &str = "0s";
+
+// Default jitter values for autorate throttling.
+pub const DEFAULT_JITTER_MAX_MILLISECONDS: u64 = 5000;
+pub const DEFAULT_JITTER_MIN_MILLISECONDS: u64 = 1000;
+
+// Trigger autorate throttling after 3 API calls.
+pub const ENGAGE_AUTORATE_THROTTLING_THRESHOLD: u32 = 3;

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -42,6 +42,10 @@ impl<'a, R> Backoff<'a, R> {
             throttler: throttler_strategy,
         }
     }
+
+    fn log_backoff_enabled(&self) {
+        log_info!("Backoff enabled with {} max retries", self.max_retries);
+    }
 }
 
 impl<'a, R: HttpRunner<Response = HttpResponse>> Backoff<'a, R> {
@@ -79,6 +83,7 @@ impl<'a, R: HttpRunner<Response = HttpResponse>> Backoff<'a, R> {
                                 if self.rate_limit_header.retry_after > Seconds::new(0) {
                                     base_wait_time = self.rate_limit_header.retry_after;
                                 }
+                                self.log_backoff_enabled();
                                 self.throttler.throttle_for(
                                     self.backoff_strategy
                                         .wait_time(base_wait_time, self.num_retries)
@@ -93,6 +98,7 @@ impl<'a, R: HttpRunner<Response = HttpResponse>> Backoff<'a, R> {
                         ) => {
                             self.num_retries += 1;
                             if self.num_retries <= self.max_retries {
+                                self.log_backoff_enabled();
                                 self.throttler.throttle_for(
                                     self.backoff_strategy
                                         .wait_time(self.default_delay_wait, self.num_retries)

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -206,7 +206,7 @@ mod tests {
             .build()
             .unwrap();
         let strategy = Box::new(Exponential);
-        let throttler = Rc::new(MockThrottler::new());
+        let throttler = Rc::new(MockThrottler::new(None));
         let bthrottler: Box<dyn ThrottleStrategy> = Box::new(Rc::clone(&throttler));
         let mut backoff = Backoff::new(&client, 3, 60, now_mock, strategy, bthrottler);
         backoff.retry_on_error(&mut request).unwrap();
@@ -228,7 +228,7 @@ mod tests {
             .build()
             .unwrap();
         let strategy = Box::new(Exponential);
-        let throttler = Rc::new(MockThrottler::new());
+        let throttler = Rc::new(MockThrottler::new(None));
         let bthrottler: Box<dyn ThrottleStrategy> = Box::new(Rc::clone(&throttler));
         let mut backoff = Backoff::new(&client, 1, 60, now_mock, strategy, bthrottler);
         match backoff.retry_on_error(&mut request) {
@@ -256,7 +256,7 @@ mod tests {
             .build()
             .unwrap();
         let strategy = Box::new(Exponential);
-        let throttler = Rc::new(MockThrottler::new());
+        let throttler = Rc::new(MockThrottler::new(None));
         let bthrottler: Box<dyn ThrottleStrategy> = Box::new(Rc::clone(&throttler));
         let mut backoff = Backoff::new(&client, 0, 60, now_mock, strategy, bthrottler);
         backoff.retry_on_error(&mut request).unwrap();
@@ -273,7 +273,7 @@ mod tests {
             .build()
             .unwrap();
         let strategy = Box::new(Exponential);
-        let throttler = Rc::new(MockThrottler::new());
+        let throttler = Rc::new(MockThrottler::new(None));
         let bthrottler: Box<dyn ThrottleStrategy> = Box::new(Rc::clone(&throttler));
         let mut backoff = Backoff::new(&client, 0, 60, now_mock, strategy, bthrottler);
         match backoff.retry_on_error(&mut request) {
@@ -300,7 +300,7 @@ mod tests {
             .build()
             .unwrap();
         let strategy = Box::new(Exponential);
-        let throttler = Rc::new(MockThrottler::new());
+        let throttler = Rc::new(MockThrottler::new(None));
         let bthrottler: Box<dyn ThrottleStrategy> = Box::new(Rc::clone(&throttler));
         let mut backoff = Backoff::new(&client, 3, 60, now_mock, strategy, bthrottler);
         backoff.retry_on_error(&mut request).unwrap();
@@ -329,7 +329,7 @@ mod tests {
             .build()
             .unwrap();
         let strategy = Box::new(Exponential);
-        let throttler = Rc::new(MockThrottler::new());
+        let throttler = Rc::new(MockThrottler::new(None));
         let bthrottler: Box<dyn ThrottleStrategy> = Box::new(Rc::clone(&throttler));
         let mut backoff = Backoff::new(&client, 3, 60, now_mock, strategy, bthrottler);
         backoff.retry_on_error(&mut request).unwrap();
@@ -359,7 +359,7 @@ mod tests {
             .build()
             .unwrap();
         let strategy = Box::new(Exponential);
-        let throttler = Rc::new(MockThrottler::new());
+        let throttler = Rc::new(MockThrottler::new(None));
         let bthrottler: Box<dyn ThrottleStrategy> = Box::new(Rc::clone(&throttler));
         let mut backoff = Backoff::new(&client, 3, 60, now_mock, strategy, bthrottler);
         backoff.retry_on_error(&mut request).unwrap();
@@ -383,7 +383,7 @@ mod tests {
             .build()
             .unwrap();
         let strategy = Box::new(Exponential);
-        let throttler = Rc::new(MockThrottler::new());
+        let throttler = Rc::new(MockThrottler::new(None));
         let bthrottler: Box<dyn ThrottleStrategy> = Box::new(Rc::clone(&throttler));
         let mut backoff = Backoff::new(&client, 1, 60, now_mock, strategy, bthrottler);
         backoff.retry_on_error(&mut request).unwrap();
@@ -405,7 +405,7 @@ mod tests {
             .build()
             .unwrap();
         let strategy = Box::new(Exponential);
-        let throttler = Rc::new(MockThrottler::new());
+        let throttler = Rc::new(MockThrottler::new(None));
         let bthrottler: Box<dyn ThrottleStrategy> = Box::new(Rc::clone(&throttler));
         let mut backoff = Backoff::new(&client, 1, 60, now_mock, strategy, bthrottler);
         match backoff.retry_on_error(&mut request) {
@@ -433,7 +433,7 @@ mod tests {
             .build()
             .unwrap();
         let strategy = Box::new(Exponential);
-        let throttler = Rc::new(MockThrottler::new());
+        let throttler = Rc::new(MockThrottler::new(None));
         let bthrottler: Box<dyn ThrottleStrategy> = Box::new(Rc::clone(&throttler));
         let mut backoff = Backoff::new(&client, 1, 60, now_mock, strategy, bthrottler);
         backoff.retry_on_error(&mut request).unwrap();
@@ -455,7 +455,7 @@ mod tests {
             .build()
             .unwrap();
         let strategy = Box::new(Exponential);
-        let throttler = Rc::new(MockThrottler::new());
+        let throttler = Rc::new(MockThrottler::new(None));
         let bthrottler: Box<dyn ThrottleStrategy> = Box::new(Rc::clone(&throttler));
         let mut backoff = Backoff::new(&client, 1, 60, now_mock, strategy, bthrottler);
         match backoff.retry_on_error(&mut request) {

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -58,7 +58,7 @@ impl<'a, R: HttpRunner<Response = Response>> Backoff<'a, R> {
                     // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
                     match err.downcast_ref::<error::GRError>() {
                         Some(error::GRError::RateLimitExceeded(headers)) => {
-                            self.rate_limit_header = headers.clone();
+                            self.rate_limit_header = *headers;
                             self.num_retries += 1;
                             if self.num_retries <= self.max_retries {
                                 let now = (self.now)();

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,4 @@
-use crate::io::{Response, ResponseField};
+use crate::io::{HttpResponse, ResponseField};
 
 pub mod filesystem;
 pub mod inmemory;
@@ -10,12 +10,12 @@ pub use nocache::NoCache;
 
 pub trait Cache<K = String> {
     fn get(&self, key: &K) -> Result<CacheState>;
-    fn set(&self, key: &K, value: &Response) -> Result<()>;
-    fn update(&self, key: &K, value: &Response, field: &ResponseField) -> Result<()>;
+    fn set(&self, key: &K, value: &HttpResponse) -> Result<()>;
+    fn update(&self, key: &K, value: &HttpResponse, field: &ResponseField) -> Result<()>;
 }
 
 pub enum CacheState {
-    Stale(Response),
-    Fresh(Response),
+    Stale(HttpResponse),
+    Fresh(HttpResponse),
     None,
 }

--- a/src/cache/inmemory.rs
+++ b/src/cache/inmemory.rs
@@ -3,13 +3,13 @@ use std::{cell::RefCell, collections::HashMap};
 use crate::{
     cache::{Cache, CacheState},
     http::Resource,
-    io::{Response, ResponseField},
+    io::{HttpResponse, ResponseField},
 };
 
 use crate::Result;
 
 pub struct InMemoryCache {
-    cache: RefCell<HashMap<String, Response>>,
+    cache: RefCell<HashMap<String, HttpResponse>>,
     expired: bool,
     pub updated: RefCell<bool>,
     pub updated_field: RefCell<ResponseField>,
@@ -47,7 +47,7 @@ impl Cache<Resource> for &InMemoryCache {
         Ok(CacheState::None)
     }
 
-    fn set(&self, key: &Resource, value: &Response) -> Result<()> {
+    fn set(&self, key: &Resource, value: &HttpResponse) -> Result<()> {
         self.cache
             .borrow_mut()
             .insert(key.url.to_string(), value.clone());
@@ -57,7 +57,7 @@ impl Cache<Resource> for &InMemoryCache {
     fn update(
         &self,
         key: &Resource,
-        value: &Response,
+        value: &HttpResponse,
         field: &crate::io::ResponseField,
     ) -> Result<()> {
         *self.updated.borrow_mut() = true;
@@ -77,7 +77,7 @@ impl Cache<String> for InMemoryCache {
         Ok(CacheState::None)
     }
 
-    fn set(&self, key: &String, value: &Response) -> Result<()> {
+    fn set(&self, key: &String, value: &HttpResponse) -> Result<()> {
         self.cache
             .borrow_mut()
             .insert(key.to_string(), value.clone());
@@ -87,7 +87,7 @@ impl Cache<String> for InMemoryCache {
     fn update(
         &self,
         key: &String,
-        value: &Response,
+        value: &HttpResponse,
         _field: &crate::io::ResponseField,
     ) -> Result<()> {
         self.set(key, value)

--- a/src/cache/nocache.rs
+++ b/src/cache/nocache.rs
@@ -1,5 +1,5 @@
 use crate::cache::{Cache, CacheState};
-use crate::io::{Response, ResponseField};
+use crate::io::{HttpResponse, ResponseField};
 
 use crate::Result;
 
@@ -9,11 +9,11 @@ impl<K> Cache<K> for NoCache {
     fn get(&self, _key: &K) -> Result<CacheState> {
         Ok(CacheState::None)
     }
-    fn set(&self, _key: &K, _value: &Response) -> Result<()> {
+    fn set(&self, _key: &K, _value: &HttpResponse) -> Result<()> {
         Ok(())
     }
 
-    fn update(&self, _key: &K, _value: &Response, _field: &ResponseField) -> Result<()> {
+    fn update(&self, _key: &K, _value: &HttpResponse, _field: &ResponseField) -> Result<()> {
         Ok(())
     }
 }

--- a/src/cmds/amps.rs
+++ b/src/cmds/amps.rs
@@ -4,7 +4,7 @@ use crate::{
     cli::amps::AmpsOptions::{self, Exec},
     dialog,
     error::GRError,
-    io::{Response, TaskRunner},
+    io::{ShellResponse, TaskRunner},
     remote::ConfigFilePath,
     shell, Result,
 };
@@ -44,7 +44,10 @@ pub fn execute(options: AmpsOptions, config_file: ConfigFilePath) -> Result<()> 
     }
 }
 
-fn list_amps(runner: impl TaskRunner<Response = Response>, amps_path: &str) -> Result<Vec<String>> {
+fn list_amps(
+    runner: impl TaskRunner<Response = ShellResponse>,
+    amps_path: &str,
+) -> Result<Vec<String>> {
     let cmd = vec!["ls", amps_path];
     let response = runner.run(cmd)?;
     if response.body.is_empty() {
@@ -89,7 +92,7 @@ impl<'a, A, R> Amp<'a, A, R> {
     }
 }
 
-impl<'a, A: Fn() -> String, R: TaskRunner<Response = Response>> Amp<'a, A, R> {
+impl<'a, A: Fn() -> String, R: TaskRunner<Response = ShellResponse>> Amp<'a, A, R> {
     fn exec_amps(&self, amp: String, base_path: &Path) -> Result<()> {
         let mut args = (self.args_prompter_fn)();
         loop {
@@ -126,12 +129,12 @@ mod tests {
 
     #[test]
     fn test_exec_amp_with_help_and_run() {
-        let response_help = Response::builder()
+        let response_help = ShellResponse::builder()
             .status(0)
             .body("this is the help".to_string())
             .build()
             .unwrap();
-        let response = Response::builder()
+        let response = ShellResponse::builder()
             .status(0)
             .body("response output".to_string())
             .build()
@@ -151,7 +154,7 @@ mod tests {
 
     #[test]
     fn test_exec_amp_with_help_and_exit() {
-        let response_help = Response::builder()
+        let response_help = ShellResponse::builder()
             .status(0)
             .body("this is the help".to_string())
             .build()
@@ -168,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_list_amps_error_if_none_available() {
-        let response = Response::builder()
+        let response = ShellResponse::builder()
             .status(0)
             .body("".to_string())
             .build()

--- a/src/github/cicd.rs
+++ b/src/github/cicd.rs
@@ -7,11 +7,11 @@ use crate::cmds::cicd::{
 use crate::remote::query;
 use crate::{
     api_traits::Cicd,
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
 };
 use crate::{http, time, Result};
 
-impl<R: HttpRunner<Response = Response>> Cicd for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> Cicd for Github<R> {
     fn list(&self, args: PipelineBodyArgs) -> Result<Vec<Pipeline>> {
         // Doc:
         // https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
@@ -60,7 +60,7 @@ impl<R> Github<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> CicdRunner for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> CicdRunner for Github<R> {
     fn list(&self, _args: RunnerListBodyArgs) -> Result<Vec<crate::cmds::cicd::Runner>> {
         todo!();
     }
@@ -82,7 +82,7 @@ impl<R: HttpRunner<Response = Response>> CicdRunner for Github<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> CicdJob for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> CicdJob for Github<R> {
     fn list(&self, _args: JobListBodyArgs) -> Result<Vec<Job>> {
         todo!();
     }

--- a/src/github/cicd.rs
+++ b/src/github/cicd.rs
@@ -7,7 +7,7 @@ use crate::cmds::cicd::{
 use crate::remote::query;
 use crate::{
     api_traits::Cicd,
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
 };
 use crate::{http, time, Result};
 

--- a/src/github/container_registry.rs
+++ b/src/github/container_registry.rs
@@ -1,7 +1,7 @@
 use crate::{
     api_traits::ContainerRegistry,
     cmds::docker::{DockerListBodyArgs, ImageMetadata, RegistryRepository, RepositoryTag},
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
     Result,
 };
 

--- a/src/github/container_registry.rs
+++ b/src/github/container_registry.rs
@@ -1,13 +1,13 @@
 use crate::{
     api_traits::ContainerRegistry,
     cmds::docker::{DockerListBodyArgs, ImageMetadata, RegistryRepository, RepositoryTag},
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
     Result,
 };
 
 use super::Github;
 
-impl<R: HttpRunner<Response = Response>> ContainerRegistry for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> ContainerRegistry for Github<R> {
     fn list_repositories(&self, _args: DockerListBodyArgs) -> Result<Vec<RegistryRepository>> {
         todo!("list_repositories")
     }

--- a/src/github/gist.rs
+++ b/src/github/gist.rs
@@ -1,7 +1,7 @@
 use crate::{
     api_traits::{ApiOperation, CodeGist, NumberDeltaErr},
     cmds::gist::{Gist, GistListBodyArgs},
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
     remote::{query, URLQueryParamBuilder},
     Result,
 };
@@ -10,7 +10,7 @@ use super::Github;
 
 // https://docs.github.com/en/rest/gists/gists?apiVersion=2022-11-28
 
-impl<R: HttpRunner<Response = Response>> CodeGist for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> CodeGist for Github<R> {
     fn list(&self, args: GistListBodyArgs) -> crate::Result<Vec<Gist>> {
         let url = self.auth_user_gist_url(false);
         query::paged(

--- a/src/github/gist.rs
+++ b/src/github/gist.rs
@@ -1,7 +1,7 @@
 use crate::{
     api_traits::{ApiOperation, CodeGist, NumberDeltaErr},
     cmds::gist::{Gist, GistListBodyArgs},
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
     remote::{query, URLQueryParamBuilder},
     Result,
 };

--- a/src/github/merge_request.rs
+++ b/src/github/merge_request.rs
@@ -11,7 +11,7 @@ use crate::{
         project::MrMemberType,
     },
     http::{self, Body},
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
     json_loads,
     remote::query,
 };
@@ -52,7 +52,7 @@ impl<R> Github<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> MergeRequest for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> MergeRequest for Github<R> {
     fn open(&self, args: MergeRequestBodyArgs) -> Result<MergeRequestResponse> {
         // https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#create-a-pull-request
         let mut body = Body::new();
@@ -355,7 +355,7 @@ impl<R: HttpRunner<Response = Response>> MergeRequest for Github<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> CommentMergeRequest for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> CommentMergeRequest for Github<R> {
     fn create(&self, args: CommentMergeRequestBodyArgs) -> Result<()> {
         let url = format!(
             "{}/repos/{}/issues/{}/comments",

--- a/src/github/merge_request.rs
+++ b/src/github/merge_request.rs
@@ -11,7 +11,7 @@ use crate::{
         project::MrMemberType,
     },
     http::{self, Body},
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
     json_loads,
     remote::query,
 };

--- a/src/github/project.rs
+++ b/src/github/project.rs
@@ -3,14 +3,14 @@ use crate::{
     cli::browse::BrowseOptions,
     cmds::project::{Member, Project, ProjectListBodyArgs, Tag},
     error::GRError,
-    io::{CmdInfo, HttpRunner, Response},
+    io::{CmdInfo, HttpResponse, HttpRunner},
     remote::{query, URLQueryParamBuilder},
 };
 
 use super::Github;
 use crate::Result;
 
-impl<R: HttpRunner<Response = Response>> RemoteProject for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> RemoteProject for Github<R> {
     fn get_project_data(&self, id: Option<i64>, path: Option<&str>) -> Result<CmdInfo> {
         // NOTE: What I call project in here is understood as repository in
         // Github parlance. In Github there is also the concept of having
@@ -109,7 +109,7 @@ impl<R: HttpRunner<Response = Response>> RemoteProject for Github<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> RemoteTag for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> RemoteTag for Github<R> {
     // https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
     fn list(&self, args: ProjectListBodyArgs) -> Result<Vec<Tag>> {
         let url = self.list_project_url(&args, false);
@@ -126,7 +126,7 @@ impl<R: HttpRunner<Response = Response>> RemoteTag for Github<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> ProjectMember for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> ProjectMember for Github<R> {
     fn list(&self, args: ProjectListBodyArgs) -> Result<Vec<Member>> {
         let url = &format!(
             "{}/repos/{}/contributors",

--- a/src/github/release.rs
+++ b/src/github/release.rs
@@ -1,14 +1,14 @@
 use crate::{
     api_traits::{ApiOperation, Deploy, DeployAsset, NumberDeltaErr},
     cmds::release::{Release, ReleaseAssetListBodyArgs, ReleaseAssetMetadata, ReleaseBodyArgs},
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
     remote::query,
     Result,
 };
 
 use super::Github;
 
-impl<R: HttpRunner<Response = Response>> Deploy for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> Deploy for Github<R> {
     fn list(&self, args: ReleaseBodyArgs) -> Result<Vec<Release>> {
         let url = format!("{}/repos/{}/releases", self.rest_api_basepath, self.path);
         query::paged(
@@ -52,7 +52,7 @@ impl<R> Github<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> DeployAsset for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> DeployAsset for Github<R> {
     fn list(&self, args: ReleaseAssetListBodyArgs) -> Result<Vec<ReleaseAssetMetadata>> {
         let url = format!(
             "{}/repos/{}/releases/{}/assets",

--- a/src/github/release.rs
+++ b/src/github/release.rs
@@ -1,7 +1,7 @@
 use crate::{
     api_traits::{ApiOperation, Deploy, DeployAsset, NumberDeltaErr},
     cmds::release::{Release, ReleaseAssetListBodyArgs, ReleaseAssetMetadata, ReleaseBodyArgs},
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
     remote::query,
     Result,
 };

--- a/src/github/trending.rs
+++ b/src/github/trending.rs
@@ -4,14 +4,14 @@ use crate::{
     api_traits::{ApiOperation, TrendingProjectURL},
     cmds::trending::TrendingProject,
     http::Headers,
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
     remote::query,
     Result,
 };
 
 use super::Github;
 
-impl<R: HttpRunner<Response = Response>> TrendingProjectURL for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> TrendingProjectURL for Github<R> {
     fn list(&self, language: String) -> Result<Vec<TrendingProject>> {
         let url = format!("https://{}/trending/{}", self.domain, language);
         let mut headers = Headers::new();
@@ -27,7 +27,7 @@ impl<R: HttpRunner<Response = Response>> TrendingProjectURL for Github<R> {
     }
 }
 
-fn parse_response(response: Response) -> Result<Vec<TrendingProject>> {
+fn parse_response(response: HttpResponse) -> Result<Vec<TrendingProject>> {
     let body = response.body;
     let proj_re = Regex::new(r#"href="/[a-zA-Z0-9_-]*/[a-zA-Z0-9_-]*/stargazers""#).unwrap();
     let description_re = Regex::new(r#"<p class="col-9 color-fg-muted my-1 pr-4">"#).unwrap();

--- a/src/github/trending.rs
+++ b/src/github/trending.rs
@@ -4,7 +4,7 @@ use crate::{
     api_traits::{ApiOperation, TrendingProjectURL},
     cmds::trending::TrendingProject,
     http::Headers,
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
     remote::query,
     Result,
 };

--- a/src/github/user.rs
+++ b/src/github/user.rs
@@ -2,11 +2,11 @@ use super::Github;
 use crate::api_traits::{ApiOperation, UserInfo};
 use crate::cmds::project::Member;
 use crate::cmds::user::UserCliArgs;
-use crate::io::{HttpRunner, Response};
+use crate::io::{HttpRunner, HttpResponse};
 use crate::remote::query;
 use crate::Result;
 
-impl<R: HttpRunner<Response = Response>> UserInfo for Github<R> {
+impl<R: HttpRunner<Response = HttpResponse>> UserInfo for Github<R> {
     fn get_auth_user(&self) -> Result<Member> {
         let url = format!("{}/user", self.rest_api_basepath);
         let user = query::get::<_, (), Member>(

--- a/src/github/user.rs
+++ b/src/github/user.rs
@@ -2,7 +2,7 @@ use super::Github;
 use crate::api_traits::{ApiOperation, UserInfo};
 use crate::cmds::project::Member;
 use crate::cmds::user::UserCliArgs;
-use crate::io::{HttpRunner, HttpResponse};
+use crate::io::{HttpResponse, HttpRunner};
 use crate::remote::query;
 use crate::Result;
 

--- a/src/gitlab/cicd.rs
+++ b/src/gitlab/cicd.rs
@@ -8,7 +8,7 @@ use crate::http::{self, Body, Headers};
 use crate::remote::{query, URLQueryParamBuilder};
 use crate::{
     api_traits::Cicd,
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
 };
 use crate::{time, Result};
 

--- a/src/gitlab/cicd.rs
+++ b/src/gitlab/cicd.rs
@@ -8,11 +8,11 @@ use crate::http::{self, Body, Headers};
 use crate::remote::{query, URLQueryParamBuilder};
 use crate::{
     api_traits::Cicd,
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
 };
 use crate::{time, Result};
 
-impl<R: HttpRunner<Response = Response>> Cicd for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> Cicd for Gitlab<R> {
     fn list(&self, args: PipelineBodyArgs) -> Result<Vec<Pipeline>> {
         let url = format!("{}/pipelines", self.rest_api_basepath());
         query::paged(
@@ -57,7 +57,7 @@ impl<R: HttpRunner<Response = Response>> Cicd for Gitlab<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> CicdRunner for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> CicdRunner for Gitlab<R> {
     fn list(&self, args: RunnerListBodyArgs) -> Result<Vec<crate::cmds::cicd::Runner>> {
         let url = self.list_runners_url(&args, false);
         query::paged(
@@ -212,7 +212,7 @@ impl From<GitlabCicdJobFields> for Job {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> CicdJob for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> CicdJob for Gitlab<R> {
     // https://docs.gitlab.com/ee/api/jobs.html#list-project-jobs
     fn list(&self, args: JobListBodyArgs) -> Result<Vec<Job>> {
         let url = format!("{}/jobs", self.rest_api_basepath());

--- a/src/gitlab/container_registry.rs
+++ b/src/gitlab/container_registry.rs
@@ -1,7 +1,7 @@
 use crate::{
     api_traits::{ApiOperation, ContainerRegistry},
     cmds::docker::{DockerListBodyArgs, ImageMetadata, RegistryRepository, RepositoryTag},
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
     remote::query,
     Result,
 };

--- a/src/gitlab/container_registry.rs
+++ b/src/gitlab/container_registry.rs
@@ -1,14 +1,14 @@
 use crate::{
     api_traits::{ApiOperation, ContainerRegistry},
     cmds::docker::{DockerListBodyArgs, ImageMetadata, RegistryRepository, RepositoryTag},
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
     remote::query,
     Result,
 };
 
 use super::Gitlab;
 
-impl<R: HttpRunner<Response = Response>> ContainerRegistry for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> ContainerRegistry for Gitlab<R> {
     fn list_repositories(&self, args: DockerListBodyArgs) -> Result<Vec<RegistryRepository>> {
         let url = format!(
             "{}/registry/repositories?tags_count=true",

--- a/src/gitlab/gist.rs
+++ b/src/gitlab/gist.rs
@@ -1,7 +1,7 @@
 use crate::{
     api_traits::CodeGist,
     cmds::gist::{Gist, GistListBodyArgs},
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
 };
 
 use super::Gitlab;

--- a/src/gitlab/gist.rs
+++ b/src/gitlab/gist.rs
@@ -1,12 +1,12 @@
 use crate::{
     api_traits::CodeGist,
     cmds::gist::{Gist, GistListBodyArgs},
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
 };
 
 use super::Gitlab;
 
-impl<R: HttpRunner<Response = Response>> CodeGist for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> CodeGist for Gitlab<R> {
     fn list(&self, _args: GistListBodyArgs) -> crate::Result<Vec<Gist>> {
         todo!()
     }

--- a/src/gitlab/merge_request.rs
+++ b/src/gitlab/merge_request.rs
@@ -12,7 +12,7 @@ use crate::remote::query;
 use crate::Result;
 use crate::{
     api_traits::MergeRequest,
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
 };
 
 use crate::json_loads;

--- a/src/gitlab/merge_request.rs
+++ b/src/gitlab/merge_request.rs
@@ -12,14 +12,14 @@ use crate::remote::query;
 use crate::Result;
 use crate::{
     api_traits::MergeRequest,
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
 };
 
 use crate::json_loads;
 
 use super::Gitlab;
 
-impl<R: HttpRunner<Response = Response>> MergeRequest for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> MergeRequest for Gitlab<R> {
     fn open(&self, args: MergeRequestBodyArgs) -> Result<MergeRequestResponse> {
         let mut body = Body::new();
         body.add("source_branch", args.source_branch);
@@ -255,7 +255,7 @@ impl<R> Gitlab<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> CommentMergeRequest for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> CommentMergeRequest for Gitlab<R> {
     fn create(&self, args: CommentMergeRequestBodyArgs) -> Result<()> {
         let url = format!(
             "{}/merge_requests/{}/notes",

--- a/src/gitlab/project.rs
+++ b/src/gitlab/project.rs
@@ -3,7 +3,7 @@ use crate::cli::browse::BrowseOptions;
 use crate::cmds::project::{Member, Project, ProjectListBodyArgs, Tag};
 use crate::error::GRError;
 use crate::gitlab::encode_path;
-use crate::io::{CmdInfo, HttpRunner, HttpResponse};
+use crate::io::{CmdInfo, HttpResponse, HttpRunner};
 use crate::remote::query;
 use crate::remote::URLQueryParamBuilder;
 use crate::Result;

--- a/src/gitlab/project.rs
+++ b/src/gitlab/project.rs
@@ -3,14 +3,14 @@ use crate::cli::browse::BrowseOptions;
 use crate::cmds::project::{Member, Project, ProjectListBodyArgs, Tag};
 use crate::error::GRError;
 use crate::gitlab::encode_path;
-use crate::io::{CmdInfo, HttpRunner, Response};
+use crate::io::{CmdInfo, HttpRunner, HttpResponse};
 use crate::remote::query;
 use crate::remote::URLQueryParamBuilder;
 use crate::Result;
 
 use super::Gitlab;
 
-impl<R: HttpRunner<Response = Response>> RemoteProject for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> RemoteProject for Gitlab<R> {
     fn get_project_data(&self, id: Option<i64>, path: Option<&str>) -> Result<CmdInfo> {
         let url = match (id, path) {
             (Some(id), None) => format!("{}/{}", self.base_project_url, id),
@@ -94,7 +94,7 @@ impl<R: HttpRunner<Response = Response>> RemoteProject for Gitlab<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> RemoteTag for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> RemoteTag for Gitlab<R> {
     // https://docs.gitlab.com/ee/api/tags.html
     fn list(&self, args: ProjectListBodyArgs) -> Result<Vec<Tag>> {
         let url = format!("{}/repository/tags", self.projects_base_url);
@@ -116,7 +116,7 @@ impl<R: HttpRunner<Response = Response>> RemoteTag for Gitlab<R> {
     // ApiOperation to reflect this.
 }
 
-impl<R: HttpRunner<Response = Response>> ProjectMember for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> ProjectMember for Gitlab<R> {
     fn list(&self, args: ProjectListBodyArgs) -> Result<Vec<Member>> {
         let url = format!("{}/members/all", self.rest_api_basepath());
         let members = query::paged(

--- a/src/gitlab/release.rs
+++ b/src/gitlab/release.rs
@@ -2,14 +2,14 @@ use crate::{
     api_traits::{ApiOperation, Deploy, DeployAsset, NumberDeltaErr},
     cmds::release::{Release, ReleaseAssetListBodyArgs, ReleaseAssetMetadata, ReleaseBodyArgs},
     http,
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
     remote::query,
     Result,
 };
 
 use super::Gitlab;
 
-impl<R: HttpRunner<Response = Response>> Deploy for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> Deploy for Gitlab<R> {
     fn list(&self, args: ReleaseBodyArgs) -> Result<Vec<Release>> {
         let url = format!("{}/releases", self.rest_api_basepath());
         query::paged(
@@ -34,7 +34,7 @@ impl<R: HttpRunner<Response = Response>> Deploy for Gitlab<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> Gitlab<R> {
     fn resource_release_metadata_url(&self) -> (String, http::Headers) {
         let url = format!("{}/releases?page=1", self.rest_api_basepath());
         let headers = self.headers();
@@ -53,7 +53,7 @@ impl<R: HttpRunner<Response = Response>> Gitlab<R> {
     }
 }
 
-impl<R: HttpRunner<Response = Response>> DeployAsset for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> DeployAsset for Gitlab<R> {
     fn list(&self, args: ReleaseAssetListBodyArgs) -> Result<Vec<ReleaseAssetMetadata>> {
         let release = self.get_release(args)?;
         let mut asset_metatadata = Vec::new();

--- a/src/gitlab/release.rs
+++ b/src/gitlab/release.rs
@@ -2,7 +2,7 @@ use crate::{
     api_traits::{ApiOperation, Deploy, DeployAsset, NumberDeltaErr},
     cmds::release::{Release, ReleaseAssetListBodyArgs, ReleaseAssetMetadata, ReleaseBodyArgs},
     http,
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
     remote::query,
     Result,
 };

--- a/src/gitlab/trending.rs
+++ b/src/gitlab/trending.rs
@@ -1,7 +1,7 @@
 use crate::{
     api_traits::TrendingProjectURL,
     cmds::trending::TrendingProject,
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
     Result,
 };
 

--- a/src/gitlab/trending.rs
+++ b/src/gitlab/trending.rs
@@ -1,13 +1,13 @@
 use crate::{
     api_traits::TrendingProjectURL,
     cmds::trending::TrendingProject,
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
     Result,
 };
 
 use super::Gitlab;
 
-impl<R: HttpRunner<Response = Response>> TrendingProjectURL for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> TrendingProjectURL for Gitlab<R> {
     fn list(&self, _language: String) -> Result<Vec<TrendingProject>> {
         unimplemented!()
     }

--- a/src/gitlab/user.rs
+++ b/src/gitlab/user.rs
@@ -2,14 +2,14 @@ use crate::{
     api_traits::{ApiOperation, UserInfo},
     cmds::{project::Member, user::UserCliArgs},
     error::GRError,
-    io::{HttpRunner, Response},
+    io::{HttpRunner, HttpResponse},
     remote::{self, query},
     Result,
 };
 
 use super::Gitlab;
 
-impl<R: HttpRunner<Response = Response>> UserInfo for Gitlab<R> {
+impl<R: HttpRunner<Response = HttpResponse>> UserInfo for Gitlab<R> {
     fn get_auth_user(&self) -> Result<Member> {
         let user = query::get::<_, (), _>(
             &self.runner,

--- a/src/gitlab/user.rs
+++ b/src/gitlab/user.rs
@@ -2,7 +2,7 @@ use crate::{
     api_traits::{ApiOperation, UserInfo},
     cmds::{project::Member, user::UserCliArgs},
     error::GRError,
-    io::{HttpRunner, HttpResponse},
+    io::{HttpResponse, HttpRunner},
     remote::{self, query},
     Result,
 };

--- a/src/http.rs
+++ b/src/http.rs
@@ -549,7 +549,7 @@ mod test {
             60,
             time::now_epoch_seconds,
             Box::new(Exponential),
-            Box::new(throttle::DynamicFixed::new()),
+            Box::new(throttle::DynamicFixed),
         );
         let paginator = Paginator::new(&client, request, "http://localhost", backoff, throttler);
         let responses = paginator.collect::<Vec<Result<HttpResponse>>>();
@@ -576,7 +576,7 @@ mod test {
             60,
             time::now_epoch_seconds,
             Box::new(Exponential),
-            Box::new(throttle::DynamicFixed::new()),
+            Box::new(throttle::DynamicFixed),
         );
         let paginator = Paginator::new(&client, request, "http://localhost", backoff, throttler);
         let responses = paginator.collect::<Vec<Result<HttpResponse>>>();
@@ -596,7 +596,7 @@ mod test {
             60,
             time::now_epoch_seconds,
             Box::new(Exponential),
-            Box::new(throttle::DynamicFixed::new()),
+            Box::new(throttle::DynamicFixed),
         );
         let paginator = Paginator::new(&client, request, "http://localhost", backoff, throttler);
         let responses = paginator.collect::<Vec<Result<HttpResponse>>>();
@@ -619,7 +619,7 @@ mod test {
             60,
             time::now_epoch_seconds,
             Box::new(Exponential),
-            Box::new(throttle::DynamicFixed::new()),
+            Box::new(throttle::DynamicFixed),
         );
         let paginator = Paginator::new(&client, request, "http://localhost", backoff, throttler);
         let responses = paginator.collect::<Vec<Result<HttpResponse>>>();
@@ -653,7 +653,7 @@ mod test {
             60,
             time::now_epoch_seconds,
             Box::new(Exponential),
-            Box::new(throttle::DynamicFixed::new()),
+            Box::new(throttle::DynamicFixed),
         );
         let paginator = Paginator::new(&client, request, "http://localhost", backoff, throttler);
         let responses = paginator.collect::<Vec<Result<HttpResponse>>>();
@@ -680,7 +680,7 @@ mod test {
             60,
             time::now_epoch_seconds,
             Box::new(Exponential),
-            Box::new(throttle::DynamicFixed::new()),
+            Box::new(throttle::DynamicFixed),
         );
         let paginator = Paginator::new(&client, request, "http://localhost", backoff, throttler);
         let responses = paginator.collect::<Vec<Result<HttpResponse>>>();
@@ -813,7 +813,7 @@ mod test {
             60,
             time::now_epoch_seconds,
             Box::new(Exponential),
-            Box::new(throttle::DynamicFixed::new()),
+            Box::new(throttle::DynamicFixed),
         );
         let paginator = Paginator::new(&client, request, "http://localhost", backoff, throttler);
         let responses = paginator.collect::<Vec<Result<HttpResponse>>>();
@@ -835,7 +835,7 @@ mod test {
             60,
             time::now_epoch_seconds,
             Box::new(Exponential),
-            Box::new(throttle::DynamicFixed::new()),
+            Box::new(throttle::DynamicFixed),
         );
         let paginator = Paginator::new(&client, request, "http://localhost", backoff, bthrottler);
         let responses = paginator.collect::<Vec<Result<HttpResponse>>>();
@@ -857,7 +857,7 @@ mod test {
             60,
             time::now_epoch_seconds,
             Box::new(Exponential),
-            Box::new(throttle::DynamicFixed::new()),
+            Box::new(throttle::DynamicFixed),
         );
         let paginator = Paginator::new(&client, request, "http://localhost", backoff, bthrottler);
         let responses = paginator.collect::<Vec<Result<HttpResponse>>>();
@@ -880,7 +880,7 @@ mod test {
             60,
             time::now_epoch_seconds,
             Box::new(Exponential),
-            Box::new(throttle::DynamicFixed::new()),
+            Box::new(throttle::DynamicFixed),
         );
         let paginator = Paginator::new(&client, request, "http://localhost", backoff, bthrottler);
         let responses = paginator.collect::<Vec<Result<HttpResponse>>>();
@@ -913,7 +913,7 @@ mod test {
             60,
             time::now_epoch_seconds,
             Box::new(Exponential),
-            Box::new(throttle::DynamicFixed::new()),
+            Box::new(throttle::DynamicFixed),
         );
         let throttler: Box<dyn ThrottleStrategy> = Box::new(NoThrottle::default());
         let paginator = Paginator::new(&client, request, "http://localhost", backoff, throttler);

--- a/src/http.rs
+++ b/src/http.rs
@@ -327,10 +327,11 @@ impl<C: Cache<Resource>> HttpRunner for Client<C> {
             Method::GET => {
                 let mut default_response = HttpResponse::builder().build().unwrap();
                 match self.cache.get(&cmd.resource) {
-                    Ok(CacheState::Fresh(response)) => {
+                    Ok(CacheState::Fresh(mut response)) => {
                         log_debug!("Cache fresh for {}", cmd.resource.url);
                         if !self.refresh_cache {
                             log_debug!("Returning local cached response");
+                            response.local_cache = true;
                             return Ok(response);
                         }
                         default_response = response;

--- a/src/http.rs
+++ b/src/http.rs
@@ -396,17 +396,19 @@ impl<'a, R: HttpRunner, T: Serialize> Paginator<'a, R, T> {
         } else {
             runner.api_max_pages(&request)
         };
+        let backoff = Backoff::new(
+            runner,
+            backoff_max_retries,
+            backoff_default_wait_time,
+            time::now_epoch_seconds,
+            Box::new(Exponential),
+            Box::new(throttle::DynamicFixed::new()),
+        );
         Paginator {
             request,
             page_url: Some(page_url.to_string()),
             iter: 0,
-            backoff: Backoff::new(
-                runner,
-                backoff_max_retries,
-                backoff_default_wait_time,
-                time::now_epoch_seconds,
-                Box::new(Exponential),
-            ),
+            backoff,
             throttler: throttle_strategy,
             max_pages,
         }

--- a/src/http/throttle.rs
+++ b/src/http/throttle.rs
@@ -25,6 +25,7 @@ impl Fixed {
 
 impl ThrottleStrategy for Fixed {
     fn throttle(&self, _response: Option<&FlowControlHeaders>) {
+        log_info!("Throttling for: {} ms", self.delay);
         thread::sleep(std::time::Duration::from_millis(*self.delay));
     }
 }
@@ -45,9 +46,29 @@ impl Random {
 
 impl ThrottleStrategy for Random {
     fn throttle(&self, _response: Option<&FlowControlHeaders>) {
+        log_info!(
+            "Throttling between: {} ms and {} ms",
+            self.delay_min,
+            self.delay_max
+        );
         let mut rng = rand::thread_rng();
         let wait_time = rng.gen_range(*self.delay_min..=*self.delay_max);
         log_info!("Sleeping for {} milliseconds", wait_time);
         thread::sleep(std::time::Duration::from_millis(wait_time));
+    }
+}
+
+#[derive(Default)]
+pub struct NoThrottle;
+
+impl NoThrottle {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ThrottleStrategy for NoThrottle {
+    fn throttle(&self, _response: Option<&FlowControlHeaders>) {
+        log_info!("No throttling enabled");
     }
 }

--- a/src/http/throttle.rs
+++ b/src/http/throttle.rs
@@ -1,0 +1,53 @@
+use std::thread;
+
+use rand::Rng;
+
+use crate::{io::FlowControlHeaders, log_info, time::Milliseconds};
+
+/// Throttle strategy
+pub trait ThrottleStrategy {
+    /// Throttle the request based on optional flow control headers.
+    /// Implementors might use the headers to adjust the throttling or ignore
+    /// them altogether. Ex. strategies could be a fixed delay, random, or based
+    /// on rate limiting headers.
+    fn throttle(&self, response: Option<&FlowControlHeaders>);
+}
+
+pub struct Fixed {
+    delay: Milliseconds,
+}
+
+impl Fixed {
+    pub fn new(delay: Milliseconds) -> Self {
+        Self { delay }
+    }
+}
+
+impl ThrottleStrategy for Fixed {
+    fn throttle(&self, _response: Option<&FlowControlHeaders>) {
+        thread::sleep(std::time::Duration::from_millis(*self.delay));
+    }
+}
+
+pub struct Random {
+    delay_min: Milliseconds,
+    delay_max: Milliseconds,
+}
+
+impl Random {
+    pub fn new(delay_min: Milliseconds, delay_max: Milliseconds) -> Self {
+        Self {
+            delay_min,
+            delay_max,
+        }
+    }
+}
+
+impl ThrottleStrategy for Random {
+    fn throttle(&self, _response: Option<&FlowControlHeaders>) {
+        let mut rng = rand::thread_rng();
+        let wait_time = rng.gen_range(*self.delay_min..=*self.delay_max);
+        log_info!("Sleeping for {} milliseconds", wait_time);
+        thread::sleep(std::time::Duration::from_millis(wait_time));
+    }
+}

--- a/src/http/throttle.rs
+++ b/src/http/throttle.rs
@@ -20,12 +20,6 @@ pub trait ThrottleStrategy {
 
 pub struct DynamicFixed;
 
-impl DynamicFixed {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
 impl ThrottleStrategy for DynamicFixed {
     fn throttle(&self, _flow_control_headers: Option<&FlowControlHeaders>) {}
 }

--- a/src/http/throttle.rs
+++ b/src/http/throttle.rs
@@ -11,19 +11,36 @@ pub trait ThrottleStrategy {
     /// them altogether. Ex. strategies could be a fixed delay, random, or based
     /// on rate limiting headers.
     fn throttle(&self, flow_control_headers: Option<&FlowControlHeaders>);
+    /// Throttle for specific amount of time.
+    fn throttle_for(&self, delay: Milliseconds) {
+        log_info!("Throttling for backoff: {} ms", delay);
+        thread::sleep(std::time::Duration::from_millis(*delay));
+    }
 }
 
-pub struct Fixed {
+pub struct DynamicFixed;
+
+impl DynamicFixed {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ThrottleStrategy for DynamicFixed {
+    fn throttle(&self, _flow_control_headers: Option<&FlowControlHeaders>) {}
+}
+
+pub struct PreFixed {
     delay: Milliseconds,
 }
 
-impl Fixed {
+impl PreFixed {
     pub fn new(delay: Milliseconds) -> Self {
         Self { delay }
     }
 }
 
-impl ThrottleStrategy for Fixed {
+impl ThrottleStrategy for PreFixed {
     fn throttle(&self, _flow_control_headers: Option<&FlowControlHeaders>) {
         log_info!("Throttling for: {} ms", self.delay);
         thread::sleep(std::time::Duration::from_millis(*self.delay));

--- a/src/http/throttle.rs
+++ b/src/http/throttle.rs
@@ -10,7 +10,7 @@ pub trait ThrottleStrategy {
     /// Implementors might use the headers to adjust the throttling or ignore
     /// them altogether. Ex. strategies could be a fixed delay, random, or based
     /// on rate limiting headers.
-    fn throttle(&self, response: Option<&FlowControlHeaders>);
+    fn throttle(&self, flow_control_headers: Option<&FlowControlHeaders>);
 }
 
 pub struct Fixed {
@@ -24,7 +24,7 @@ impl Fixed {
 }
 
 impl ThrottleStrategy for Fixed {
-    fn throttle(&self, _response: Option<&FlowControlHeaders>) {
+    fn throttle(&self, _flow_control_headers: Option<&FlowControlHeaders>) {
         log_info!("Throttling for: {} ms", self.delay);
         thread::sleep(std::time::Duration::from_millis(*self.delay));
     }
@@ -45,7 +45,7 @@ impl Random {
 }
 
 impl ThrottleStrategy for Random {
-    fn throttle(&self, _response: Option<&FlowControlHeaders>) {
+    fn throttle(&self, _flow_control_headers: Option<&FlowControlHeaders>) {
         log_info!(
             "Throttling between: {} ms and {} ms",
             self.delay_min,
@@ -68,7 +68,7 @@ impl NoThrottle {
 }
 
 impl ThrottleStrategy for NoThrottle {
-    fn throttle(&self, _response: Option<&FlowControlHeaders>) {
+    fn throttle(&self, _flow_control_headers: Option<&FlowControlHeaders>) {
         log_info!("No throttling enabled");
     }
 }

--- a/src/http/throttle.rs
+++ b/src/http/throttle.rs
@@ -1,8 +1,15 @@
+//! Throttle module provides different strategies to throttle requests based on
+//! flow control headers or provided delays.
+
 use std::thread;
 
 use rand::Rng;
 
-use crate::{io::FlowControlHeaders, log_info, time::Milliseconds};
+use crate::{
+    io::FlowControlHeaders,
+    log_debug, log_info,
+    time::{self, Milliseconds, Seconds},
+};
 
 /// Throttle strategy
 pub trait ThrottleStrategy {
@@ -13,7 +20,7 @@ pub trait ThrottleStrategy {
     fn throttle(&self, flow_control_headers: Option<&FlowControlHeaders>);
     /// Throttle for specific amount of time.
     fn throttle_for(&self, delay: Milliseconds) {
-        log_info!("Throttling for backoff: {} ms", delay);
+        log_info!("Throttling for : {} ms", delay);
         thread::sleep(std::time::Duration::from_millis(*delay));
     }
 }
@@ -85,5 +92,74 @@ impl NoThrottle {
 impl ThrottleStrategy for NoThrottle {
     fn throttle(&self, _flow_control_headers: Option<&FlowControlHeaders>) {
         log_info!("No throttling enabled");
+    }
+}
+
+/// AutoRate implements an automatic throttling algorithm that limits the
+/// rate of requests based on flow control headers from the HTTP response plus a
+/// fixed random delay to avoid being predictable and too fast for the server.
+/// Inspiration ref: https://en.wikipedia.org/wiki/Leaky_bucket
+pub struct AutoRate {
+    /// Max interval milliseconds added to the automatic throttle. In order to
+    /// avoid predictability, the minimum range is 1 second. The jitter is the
+    /// max interval added to the automatic throttle. (1, jitter) milliseconds.
+    jitter_max: Milliseconds,
+    jitter_min: Milliseconds,
+    now: fn() -> Seconds,
+}
+
+const DEFAULT_JITTER_MAX_MILLISECONDS: u64 = 5000;
+const DEFAULT_JITTER_MIN_MILLISECONDS: u64 = 1000;
+
+impl Default for AutoRate {
+    fn default() -> Self {
+        Self {
+            jitter_max: Milliseconds::from(DEFAULT_JITTER_MAX_MILLISECONDS),
+            jitter_min: Milliseconds::from(DEFAULT_JITTER_MIN_MILLISECONDS),
+            now: time::now_epoch_seconds,
+        }
+    }
+}
+
+impl ThrottleStrategy for AutoRate {
+    fn throttle(&self, flow_control_headers: Option<&FlowControlHeaders>) {
+        match flow_control_headers {
+            Some(headers) => {
+                let rate_limit_headers = headers.get_rate_limit_header();
+                match *rate_limit_headers {
+                    Some(headers) => {
+                        // In order to avoid rate limited, we need to space the
+                        // requests evenly using: time to ratelimit-reset
+                        // (secs)/ratelimit-remaining (requests).
+                        let now = *(self.now)();
+                        log_debug!("Current epoch: {}", now);
+                        log_debug!("Rate limit reset: {}", headers.reset);
+                        let time_to_reset = headers.reset.saturating_sub(now);
+                        log_debug!("Time to reset: {}", time_to_reset);
+                        log_debug!("Remaining requests: {}", headers.remaining);
+                        let delay = time_to_reset / headers.remaining as u64;
+                        // Avoid predictability and being too fast. We could end up
+                        // being too fast when the amount of remaining requests
+                        // is high and the reset time is low. We additionally
+                        // wait in between jitter_min and jitter_max milliseconds.
+                        let additional_delay =
+                            rand::thread_rng().gen_range(*self.jitter_min..=*self.jitter_max);
+                        let total_delay = delay + additional_delay;
+                        log_info!("AutoRate throttling enabled");
+                        self.throttle_for(Milliseconds::from(total_delay));
+                    }
+                    None => {
+                        // When the response has status 304 Not Modified, we don't get
+                        // any rate limiting headers. In this case, we just throttle
+                        // randomly between the min and max jitter.
+                        let rand_delay_jitter =
+                            rand::thread_rng().gen_range(*self.jitter_min..=*self.jitter_max);
+                        log_info!("AutoRate throttling enabled");
+                        self.throttle_for(Milliseconds::from(rand_delay_jitter));
+                    }
+                }
+            }
+            None => (),
+        };
     }
 }

--- a/src/http/throttle.rs
+++ b/src/http/throttle.rs
@@ -18,6 +18,10 @@ pub trait ThrottleStrategy {
     }
 }
 
+/// Dynamically throttles for the amount of time specified in the throttle_for
+/// method using the default trait implementation. As opposed to the PreFixed,
+/// which takes a fixed delay in the constructor and throttles for that amount
+/// of time every time.
 pub struct DynamicFixed;
 
 impl ThrottleStrategy for DynamicFixed {

--- a/src/io.rs
+++ b/src/io.rs
@@ -7,7 +7,7 @@ use crate::{
     http::{self, Headers, Request},
     log_info,
     remote::RemoteURL,
-    time::{self, Milliseconds, Seconds},
+    time::{self, Seconds},
     Result,
 };
 use regex::Regex;
@@ -16,10 +16,7 @@ use std::{
     ffi::OsStr,
     fmt::{self, Display, Formatter},
     rc::Rc,
-    thread,
 };
-
-use rand::Rng;
 
 /// A trait that handles the execution of processes with a finite lifetime. For
 /// example, it can be an in-memory process for testing or a shell command doing
@@ -42,18 +39,6 @@ pub trait HttpRunner {
     fn run<T: Serialize>(&self, cmd: &mut Request<T>) -> Result<Self::Response>;
     /// Return the number of API MAX PAGES allowed for the given Request.
     fn api_max_pages<T: Serialize>(&self, cmd: &Request<T>) -> u32;
-    /// Milliseconds to wait before executing the next request
-    fn throttle(&self, milliseconds: Milliseconds) {
-        thread::sleep(std::time::Duration::from_millis(*milliseconds));
-    }
-    /// Random wait time between the given range before submitting the next HTTP
-    /// request. The wait time is in milliseconds. The range is inclusive.
-    fn throttle_range(&self, min: Milliseconds, max: Milliseconds) {
-        let mut rng = rand::thread_rng();
-        let wait_time = rng.gen_range(*min..=*max);
-        log_info!("Sleeping for {} milliseconds", wait_time);
-        thread::sleep(std::time::Duration::from_millis(wait_time));
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/io.rs
+++ b/src/io.rs
@@ -143,6 +143,10 @@ impl HttpResponse {
             http::Method::PATCH | http::Method::PUT => self.status >= 200 && self.status < 300,
         }
     }
+
+    pub fn update_rate_limit_headers(&mut self, headers: RateLimitHeader) {
+        self.flow_control_headers.rate_limit_header = Rc::new(Some(headers));
+    }
 }
 
 const NEXT: &str = "next";

--- a/src/io.rs
+++ b/src/io.rs
@@ -149,7 +149,7 @@ const NEXT: &str = "next";
 const LAST: &str = "last";
 pub const LINK_HEADER: &str = "link";
 
-pub fn parse_link_headers(link: &str) -> PageHeader {
+fn parse_link_headers(link: &str) -> PageHeader {
     lazy_static! {
         static ref RE_URL: Regex = Regex::new(r#"<([^>]+)>;\s*rel="([^"]+)""#).unwrap();
         static ref RE_PAGE_NUMBER: Regex = Regex::new(r"[^(per_)]page=(\d+)").unwrap();

--- a/src/io.rs
+++ b/src/io.rs
@@ -98,6 +98,8 @@ pub struct HttpResponse {
     pub headers: Option<Headers>,
     #[builder(setter(into), default)]
     pub flow_control_headers: FlowControlHeaders,
+    #[builder(setter(into), default)]
+    pub local_cache: bool,
 }
 
 impl HttpResponse {

--- a/src/io.rs
+++ b/src/io.rs
@@ -96,7 +96,7 @@ pub struct HttpResponse {
     /// Optional headers. Mostly used by HTTP downstream HTTP responses
     #[builder(setter(into, strip_option), default)]
     pub headers: Option<Headers>,
-    #[builder(setter(into, strip_option), default)]
+    #[builder(setter(into), default)]
     pub flow_control_headers: FlowControlHeaders,
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -129,6 +129,10 @@ impl HttpResponse {
         self.flow_control_headers.get_rate_limit_header()
     }
 
+    pub fn get_flow_control_headers(&self) -> &FlowControlHeaders {
+        &self.flow_control_headers
+    }
+
     pub fn get_etag(&self) -> Option<&str> {
         self.header("etag")
     }

--- a/src/remote/query.rs
+++ b/src/remote/query.rs
@@ -243,7 +243,7 @@ where
         backoff_wait_time = list_args.get_args.backoff_retry_after;
     }
     let throttle_strategy: Box<dyn ThrottleStrategy> = match throttle_time {
-        Some(throttle_time) => Box::new(throttle::Fixed::new(throttle_time)),
+        Some(throttle_time) => Box::new(throttle::PreFixed::new(throttle_time)),
         None => match throttle_range {
             Some((min, max)) => Box::new(throttle::Random::new(min, max)),
             None => Box::new(throttle::NoThrottle::new()),

--- a/src/remote/query.rs
+++ b/src/remote/query.rs
@@ -257,7 +257,7 @@ where
         backoff_wait_time,
         time::now_epoch_seconds,
         Box::new(Exponential),
-        Box::new(throttle::DynamicFixed::new()),
+        Box::new(throttle::DynamicFixed),
     );
     let paginator = Paginator::new(runner, request, url, backoff, throttle_strategy);
     let all_data = paginator

--- a/src/remote/query.rs
+++ b/src/remote/query.rs
@@ -248,7 +248,7 @@ where
         Some(throttle_time) => Box::new(throttle::PreFixed::new(throttle_time)),
         None => match throttle_range {
             Some((min, max)) => Box::new(throttle::Random::new(min, max)),
-            None => Box::new(throttle::NoThrottle::new()),
+            None => Box::new(throttle::AutoRate::default()),
         },
     };
     let backoff = Backoff::new(

--- a/src/remote/query.rs
+++ b/src/remote/query.rs
@@ -255,7 +255,7 @@ where
         url,
         backoff_max_retries,
         backoff_wait_time,
-        throttle_strategy.as_ref(),
+        throttle_strategy,
     );
     let all_data = paginator
         .map(|response| {

--- a/src/remote/query.rs
+++ b/src/remote/query.rs
@@ -19,7 +19,7 @@ use crate::{
     Result,
 };
 
-fn get_remote_resource_headers<'a, R: HttpRunner<Response = HttpResponse>>(
+fn get_remote_resource_headers<R: HttpRunner<Response = HttpResponse>>(
     runner: &Arc<R>,
     url: &str,
     request_headers: Headers,
@@ -255,7 +255,7 @@ where
         url,
         backoff_max_retries,
         backoff_wait_time,
-        &throttle_strategy,
+        throttle_strategy.as_ref(),
     );
     let all_data = paginator
         .map(|response| {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,5 +1,5 @@
 use crate::error;
-use crate::io::Response;
+use crate::io::ShellResponse;
 use crate::io::TaskRunner;
 use crate::Result;
 use std::ffi::OsStr;
@@ -13,7 +13,7 @@ use std::thread;
 pub struct BlockingCommand;
 
 impl TaskRunner for BlockingCommand {
-    type Response = Response;
+    type Response = ShellResponse;
 
     fn run<T>(&self, cmd: T) -> Result<Self::Response>
     where
@@ -24,7 +24,7 @@ impl TaskRunner for BlockingCommand {
     }
 }
 
-fn run_args<T>(args: T) -> Result<Response>
+fn run_args<T>(args: T) -> Result<ShellResponse>
 where
     T: IntoIterator,
     T::Item: AsRef<OsStr>,
@@ -32,7 +32,7 @@ where
     let args: Vec<_> = args.into_iter().collect();
     let mut process = process::Command::new(&args[0]);
     process.args(&args[1..]);
-    let mut response_builder = Response::builder();
+    let mut response_builder = ShellResponse::builder();
     match process.output() {
         Ok(output) => {
             let status_code = output.status.code().unwrap_or(0);
@@ -59,7 +59,7 @@ where
 pub struct StreamingCommand;
 
 impl TaskRunner for StreamingCommand {
-    type Response = Response;
+    type Response = ShellResponse;
 
     fn run<T>(&self, cmd: T) -> Result<Self::Response>
     where
@@ -94,7 +94,10 @@ impl TaskRunner for StreamingCommand {
         stdout_handle.join().unwrap();
         stderr_handle.join().unwrap();
         let _ = child.wait()?;
-        Ok(Response::builder().status(0).body("".to_string()).build()?)
+        Ok(ShellResponse::builder()
+            .status(0)
+            .body("".to_string())
+            .build()?)
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -5,7 +5,11 @@ pub mod utils {
         api_traits::ApiOperation,
         config::ConfigProperties,
         error,
-        http::{self, Headers, Request},
+        http::{
+            self,
+            throttle::{self, ThrottleStrategyType},
+            Headers, Request,
+        },
         io::{self, HttpResponse, HttpRunner, ShellResponse, TaskRunner},
         time::Milliseconds,
         Result,
@@ -385,13 +389,15 @@ pub mod utils {
     pub struct MockThrottler {
         throttled: RefCell<u32>,
         milliseconds_throttled: RefCell<Milliseconds>,
+        strategy: throttle::ThrottleStrategyType,
     }
 
     impl MockThrottler {
-        pub fn new() -> Self {
+        pub fn new(strategy_type: Option<ThrottleStrategyType>) -> Self {
             Self {
                 throttled: RefCell::new(0),
                 milliseconds_throttled: RefCell::new(Milliseconds::new(0)),
+                strategy: strategy_type.unwrap_or(ThrottleStrategyType::NoThrottle),
             }
         }
 
@@ -415,6 +421,10 @@ pub mod utils {
             *throttled += 1;
             let mut milliseconds_throttled = self.milliseconds_throttled.borrow_mut();
             *milliseconds_throttled += delay;
+        }
+
+        fn strategy(&self) -> ThrottleStrategyType {
+            self.strategy.clone()
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -171,20 +171,6 @@ pub mod utils {
                     .unwrap_or(&ApiOperation::Project),
             )
         }
-
-        fn throttle(&self, milliseconds: Milliseconds) {
-            let mut throttled = self.throttled.borrow_mut();
-            *throttled += 1;
-            let mut milliseconds_throttled = self.milliseconds_throttled.borrow_mut();
-            *milliseconds_throttled += milliseconds;
-        }
-
-        fn throttle_range(&self, min: Milliseconds, _max: Milliseconds) {
-            let mut throttled = self.throttled.borrow_mut();
-            *throttled += 1;
-            let mut milliseconds_throttled = self.milliseconds_throttled.borrow_mut();
-            *milliseconds_throttled += min;
-        }
     }
 
     pub struct ConfigMock {
@@ -398,17 +384,23 @@ pub mod utils {
 
     pub struct MockThrottler {
         throttled: RefCell<u32>,
+        milliseconds_throttled: RefCell<Milliseconds>,
     }
 
     impl MockThrottler {
         pub fn new() -> Self {
             Self {
                 throttled: RefCell::new(0),
+                milliseconds_throttled: RefCell::new(Milliseconds::new(0)),
             }
         }
 
         pub fn throttled(&self) -> Ref<u32> {
             self.throttled.borrow()
+        }
+
+        pub fn milliseconds_throttled(&self) -> Ref<Milliseconds> {
+            self.milliseconds_throttled.borrow()
         }
     }
 
@@ -416,6 +408,13 @@ pub mod utils {
         fn throttle(&self, _response: Option<&io::FlowControlHeaders>) {
             let mut throttled = self.throttled.borrow_mut();
             *throttled += 1;
+        }
+
+        fn throttle_for(&self, delay: Milliseconds) {
+            let mut throttled = self.throttled.borrow_mut();
+            *throttled += 1;
+            let mut milliseconds_throttled = self.milliseconds_throttled.borrow_mut();
+            *milliseconds_throttled += delay;
         }
     }
 }

--- a/tests/fs_cache_test.rs
+++ b/tests/fs_cache_test.rs
@@ -8,7 +8,7 @@ use gr::{
     cache::{filesystem::FileCache, Cache, CacheState},
     config::ConfigProperties,
     http::{Headers, Resource},
-    io::{Response, ResponseField},
+    io::{HttpResponse, ResponseField},
 };
 
 struct TestConfig {
@@ -41,7 +41,7 @@ fn test_file_cache_fresh() {
 
     let resource = Resource::new("https://api.example.com/test", Some(ApiOperation::Project));
 
-    let response = Response::builder()
+    let response = HttpResponse::builder()
         .status(200)
         .body("Test response body".to_string())
         .headers({
@@ -90,7 +90,7 @@ fn test_file_cache_stale_user_expired_no_cache() {
 
     let resource = Resource::new("https://api.example.com/test", Some(ApiOperation::Project));
 
-    let response = Response::builder()
+    let response = HttpResponse::builder()
         .status(200)
         .body("Test response body".to_string())
         .headers({
@@ -136,7 +136,7 @@ fn test_file_cache_fresh_user_expired_but_under_max_age() {
 
     let resource = Resource::new("https://api.example.com/test", Some(ApiOperation::Project));
 
-    let response = Response::builder()
+    let response = HttpResponse::builder()
         .status(200)
         .body("Test response body".to_string())
         .headers({
@@ -185,7 +185,7 @@ fn test_cache_stale_both_user_expired_and_max_aged_expired() {
 
     let resource = Resource::new("https://api.example.com/test", Some(ApiOperation::Project));
 
-    let response = Response::builder()
+    let response = HttpResponse::builder()
         .status(200)
         .body("Test response body".to_string())
         .headers({
@@ -228,7 +228,7 @@ fn test_cache_update_refreshes_cache() {
     let resource = Resource::new("https://api.example.com/test", Some(ApiOperation::Project));
 
     // First response
-    let response = Response::builder()
+    let response = HttpResponse::builder()
         .status(200)
         .body("Test response body".to_string())
         .headers({
@@ -242,7 +242,7 @@ fn test_cache_update_refreshes_cache() {
     file_cache.set(&resource, &response).unwrap();
 
     // Second call, we get a 304 response
-    let new_response = Response::builder()
+    let new_response = HttpResponse::builder()
         .status(304)
         .headers(Headers::new())
         .build()

--- a/tests/http_test.rs
+++ b/tests/http_test.rs
@@ -4,7 +4,7 @@ use gr::cache::{Cache, InMemoryCache, NoCache};
 use gr::config::ConfigProperties;
 use gr::error::GRError;
 use gr::http::{Client, Headers, Method, Request};
-use gr::io::{HttpRunner, Response, ResponseField};
+use gr::io::{HttpRunner, HttpResponse, ResponseField};
 use httpmock::prelude::*;
 use httpmock::Method::{GET, HEAD, PATCH, POST};
 
@@ -120,7 +120,7 @@ fn test_http_gathers_from_inmemory_fresh_cache() {
         "default_branch": "main",
     }"#;
 
-    let response = Response::builder()
+    let response = HttpResponse::builder()
         .status(200)
         .body(body_str.to_string())
         .build()
@@ -180,7 +180,7 @@ fn test_http_gathers_from_inmemory_stale_cache_server_304() {
     let mut headers = Headers::new();
     headers.set("etag".to_string(), "1234".to_string());
     headers.set("Max-Age".to_string(), "0".to_string());
-    let response = Response::builder()
+    let response = HttpResponse::builder()
         .status(200)
         .body(body_str.to_string())
         .headers(headers)

--- a/tests/http_test.rs
+++ b/tests/http_test.rs
@@ -4,7 +4,7 @@ use gr::cache::{Cache, InMemoryCache, NoCache};
 use gr::config::ConfigProperties;
 use gr::error::GRError;
 use gr::http::{Client, Headers, Method, Request};
-use gr::io::{HttpRunner, HttpResponse, ResponseField};
+use gr::io::{HttpResponse, HttpRunner, ResponseField};
 use httpmock::prelude::*;
 use httpmock::Method::{GET, HEAD, PATCH, POST};
 
@@ -150,6 +150,8 @@ fn test_http_gathers_from_inmemory_fresh_cache() {
     assert_eq!(response.status, 200);
     assert!(response.body.contains("id"));
 
+    assert!(response.local_cache);
+
     // Mock was never called. We used the cache
     server_mock.assert_hits(0);
 }
@@ -196,6 +198,7 @@ fn test_http_gathers_from_inmemory_stale_cache_server_304() {
 
     let response = runner.run(&mut request).unwrap();
     assert_eq!(response.status, 200);
+    assert!(!response.local_cache);
     assert!(response.body.contains("id"));
 
     // While do we have a cache, the cache was expired, hence we expect the


### PR DESCRIPTION
This pull request introduces several key improvements and refactorings related
to HTTP response handling, throttling, and caching:

Link and rate limit headers are now encapsulated in dedicated structures for
improved readability and usability.  The responses have been split into
HttpResponse and ShellResponse, providing better separation of concerns.

A new throttle module has been added, providing a strategy for auto throttling

Local cache responses are excluded from throttling to optimize performance.
