### PR TITLE
Add --gpt-prompt flag to provide a prompt ready to be used with a GPT engine

### DIFF
--- a/src/cli/merge_request.rs
+++ b/src/cli/merge_request.rs
@@ -120,6 +120,11 @@ struct CreateMergeRequest {
     /// Accept the default title, description, and target branch
     #[clap(long, short)]
     pub auto: bool,
+    /// Provide a GPT prompt with the summary of the outgoing changes. This can
+    /// be used to automatically create a title and a description for the
+    /// outgoing merge request. Requires `--summary short` or `--summary long`.
+    #[clap(long, short, requires = "summary")]
+    pub gpt_prompt: bool,
     /// Automatically fetch the latest changes from the remote repository
     #[clap(long, value_name = "REMOTE_ALIAS")]
     pub fetch: Option<String>,
@@ -292,6 +297,7 @@ impl From<CreateMergeRequest> for MergeRequestOptions {
                 .dry_run(options.dry_run)
                 .summary(options.summary.into())
                 .patch(options.patch)
+                .gpt_prompt(options.gpt_prompt)
                 .build()
                 .unwrap(),
         )

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -18,6 +18,27 @@ use std::{
 use super::common::{self, get_user};
 use super::project::{Member, Project};
 
+/// GPT_PROMPT is a template for the GPT prompt to generate a merge request
+/// description given a list of commit messages.
+const GPT_PROMPT: &str = r#"
+Act like a professional software engineer. You have finished a new feature and
+want to create a new pull request for someone else to review your changes. You
+will be provided by a list of commit messages with the following format:
+
+- Newest commit is at the very bottom.
+- The subject of the commit message is followed by a dash `-` and its short SHA.
+- If there is a body, it will be immediately below the subject `-` short SHA line.
+
+You will provide a description of these changes. The description must not
+mention commit SHAs and it must not mention the number of commits included. Be
+concise and provide at most two paragraphs describing the changes. Use
+imperative mode, be short and to the point. The description for the pull
+request will begin with the sentence `This merge request`.
+
+Once you have finished, then provide a title for it.
+
+Below are the changes:"#;
+
 #[derive(Builder, Clone, Debug, Default)]
 #[builder(default)]
 pub struct MergeRequestResponse {
@@ -199,6 +220,8 @@ pub struct MergeRequestCliArgs {
     pub summary: SummaryOptions,
     #[builder(default)]
     pub patch: bool,
+    #[builder(default)]
+    pub gpt_prompt: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -670,6 +693,9 @@ fn summary(mr_body: MergeRequestBody, cli_args: &MergeRequestCliArgs) -> Result<
             "No outgoing commits found. Please commit your changes.".to_string(),
         )
         .into());
+    }
+    if cli_args.gpt_prompt {
+        println!("{}", GPT_PROMPT);
     }
     println!("\n{}", outgoing_commits);
     Ok(())


### PR DESCRIPTION
The --gpt-prompt flag will be used to automatically create a prompt that
can be used with GPT engines to create a title and a description for the
outgoing commit messages.