### PR TITLE
Read title and description from file for merge requests

### DIFF
--- a/src/cli/merge_request.rs
+++ b/src/cli/merge_request.rs
@@ -101,7 +101,7 @@ struct CreateMergeRequest {
     pub title: Option<String>,
     /// Gather title and description from the specified commit message
     #[clap(long, group = "title_msg", value_name = "SHA")]
-    pub title_from_commit: Option<String>,
+    pub body_from_commit: Option<String>,
     /// Description of the merge request
     #[clap(long)]
     pub description: Option<String>,
@@ -279,7 +279,7 @@ impl From<CreateMergeRequest> for MergeRequestOptions {
         MergeRequestOptions::Create(
             MergeRequestCliArgs::builder()
                 .title(options.title)
-                .title_from_commit(options.title_from_commit)
+                .body_from_commit(options.body_from_commit)
                 .description(options.description)
                 .description_from_file(options.description_from_file)
                 .target_branch(options.target_branch)

--- a/src/cli/merge_request.rs
+++ b/src/cli/merge_request.rs
@@ -294,6 +294,7 @@ impl From<CreateMergeRequest> for MergeRequestOptions {
             MergeRequestCliArgs::builder()
                 .title(options.title)
                 .body_from_commit(options.body_from_commit)
+                .body_from_file(options.body_from_file)
                 .description(options.description)
                 .description_from_file(options.description_from_file)
                 .target_branch(options.target_branch)

--- a/src/cli/merge_request.rs
+++ b/src/cli/merge_request.rs
@@ -97,17 +97,31 @@ impl From<Option<SummaryCliOptions>> for SummaryOptions {
 #[derive(Parser)]
 struct CreateMergeRequest {
     /// Title of the merge request
-    #[clap(long, group = "title_msg")]
+    #[clap(long, group = "title_input")]
     pub title: Option<String>,
     /// Gather title and description from the specified commit message
-    #[clap(long, group = "title_msg", value_name = "SHA")]
+    #[clap(
+        long,
+        group = "title_input",
+        group = "description_input",
+        value_name = "SHA"
+    )]
     pub body_from_commit: Option<String>,
+    /// Gather merge request title and description from the specified file. If "-" is
+    /// provided, read from STDIN. Title and description are separated by a blank line.
+    #[clap(
+        long,
+        group = "title_input",
+        group = "description_input",
+        value_name = "FILE"
+    )]
+    pub body_from_file: Option<String>,
     /// Description of the merge request
-    #[clap(long)]
+    #[clap(long, group = "description_input")]
     pub description: Option<String>,
     /// Gather merge request description from the specified file. If "-" is
     /// provided, read from STDIN
-    #[clap(long, value_name = "FILE")]
+    #[clap(long, group = "description_input", value_name = "FILE")]
     pub description_from_file: Option<String>,
     /// Provides a list of outgoing commit SHAs and messages with subject
     /// (short) and body (long) to STDOUT, then exits. No merge request is created.
@@ -568,5 +582,116 @@ mod test {
             }
             _ => panic!("Expected MergeRequestOptions::Create"),
         }
+    }
+
+    #[test]
+    fn test_title_description_cli_combinations() {
+        // Valid combinations
+        assert!(Args::try_parse_from(["gr", "mr", "create", "--title", "test"]).is_ok());
+        assert!(Args::try_parse_from(["gr", "mr", "create", "--description", "test"]).is_ok());
+        assert!(Args::try_parse_from([
+            "gr",
+            "mr",
+            "create",
+            "--title",
+            "test",
+            "--description",
+            "test"
+        ])
+        .is_ok());
+        assert!(Args::try_parse_from([
+            "gr",
+            "mr",
+            "create",
+            "--title",
+            "test",
+            "--description-from-file",
+            "file.txt"
+        ])
+        .is_ok());
+        assert!(
+            Args::try_parse_from(["gr", "mr", "create", "--body-from-commit", "abc123"]).is_ok()
+        );
+        assert!(
+            Args::try_parse_from(["gr", "mr", "create", "--body-from-file", "file.txt"]).is_ok()
+        );
+
+        // Invalid combinations
+        assert!(Args::try_parse_from([
+            "gr",
+            "mr",
+            "create",
+            "--body-from-commit",
+            "abc123",
+            "--body-from-file",
+            "file.txt"
+        ])
+        .is_err());
+
+        assert!(Args::try_parse_from([
+            "gr",
+            "mr",
+            "create",
+            "--body-from-commit",
+            "abc123",
+            "--title",
+            "test"
+        ])
+        .is_err());
+
+        assert!(Args::try_parse_from([
+            "gr",
+            "mr",
+            "create",
+            "--body-from-file",
+            "/tmp/file.txt",
+            "--title",
+            "test"
+        ])
+        .is_err());
+
+        assert!(Args::try_parse_from([
+            "gr",
+            "mr",
+            "create",
+            "--body-from-file",
+            "file.txt",
+            "--description",
+            "test"
+        ])
+        .is_err());
+
+        assert!(Args::try_parse_from([
+            "gr",
+            "mr",
+            "create",
+            "--body-from-commit",
+            "file.txt",
+            "--description",
+            "test"
+        ])
+        .is_err());
+
+        assert!(Args::try_parse_from([
+            "gr",
+            "mr",
+            "create",
+            "--description",
+            "test",
+            "--description-from-file",
+            "file.txt"
+        ])
+        .is_err());
+
+        assert!(Args::try_parse_from([
+            "gr",
+            "mr",
+            "create",
+            "--body-from-file",
+            "file.txt",
+            "--description-from-file",
+            "file.txt"
+        ])
+        .is_err());
     }
 }

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -198,6 +198,8 @@ impl MergeRequestListBodyArgs {
 pub struct MergeRequestCliArgs {
     pub title: Option<String>,
     pub body_from_commit: Option<String>,
+    #[builder(default)]
+    pub body_from_file: Option<String>,
     pub description: Option<String>,
     pub description_from_file: Option<String>,
     pub target_branch: Option<String>,

--- a/src/cmds/merge_request.rs
+++ b/src/cmds/merge_request.rs
@@ -197,7 +197,7 @@ impl MergeRequestListBodyArgs {
 #[derive(Builder, Clone)]
 pub struct MergeRequestCliArgs {
     pub title: Option<String>,
-    pub title_from_commit: Option<String>,
+    pub body_from_commit: Option<String>,
     pub description: Option<String>,
     pub description_from_file: Option<String>,
     pub target_branch: Option<String>,
@@ -732,15 +732,15 @@ fn cmds<R: BufRead + Send + Sync + 'static>(
     let git_status_cmd = || -> Result<CmdInfo> { git::status(status_runner) };
     let title = cli_args.title.clone();
     let title = title.unwrap_or("".to_string());
-    let title_from_commit = cli_args.title_from_commit.clone();
+    let body_from_commit = cli_args.body_from_commit.clone();
     // if we are required to gather the title from specific commit, gather also
     // its description. The description will be pulled from the same commit as
     // the title.
-    let description_commit = cli_args.title_from_commit.clone();
+    let description_commit = cli_args.body_from_commit.clone();
     let commit_summary_runner = task_runner.clone();
     let git_title_cmd = move || -> Result<CmdInfo> {
         if title.is_empty() {
-            git::commit_summary(commit_summary_runner, &title_from_commit)
+            git::commit_summary(commit_summary_runner, &body_from_commit)
         } else {
             Ok(CmdInfo::CommitSummary(title.clone()))
         }
@@ -1424,7 +1424,7 @@ mod tests {
         let remote = Arc::new(MockRemoteProject::default());
         let cli_args = MergeRequestCliArgs::builder()
             .title(Some("title cli".to_string()))
-            .title_from_commit(None)
+            .body_from_commit(None)
             .description(None)
             .description_from_file(None)
             .target_branch(Some("target-branch".to_string()))
@@ -1463,7 +1463,7 @@ mod tests {
         let remote = Arc::new(MockRemoteProject::default());
         let cli_args = MergeRequestCliArgs::builder()
             .title(None)
-            .title_from_commit(None)
+            .body_from_commit(None)
             .description(None)
             .description_from_file(None)
             .target_branch(Some("target-branch".to_string()))
@@ -1500,7 +1500,7 @@ mod tests {
         let remote = Arc::new(MockRemoteProject::default());
         let cli_args = MergeRequestCliArgs::builder()
             .title(None)
-            .title_from_commit(None)
+            .body_from_commit(None)
             .description(None)
             .description_from_file(Some("description_file.txt".to_string()))
             .target_branch(Some("target-branch".to_string()))
@@ -1671,7 +1671,7 @@ mod tests {
         let remote = Arc::new(MockRemoteProject::default());
         let cli_args = MergeRequestCliArgs::builder()
             .title(Some("title cli".to_string()))
-            .title_from_commit(None)
+            .body_from_commit(None)
             .description(None)
             .description_from_file(None)
             .target_branch(Some("target-branch".to_string()))

--- a/src/io.rs
+++ b/src/io.rs
@@ -41,6 +41,9 @@ pub trait HttpRunner {
     fn api_max_pages<T: Serialize>(&self, cmd: &Request<T>) -> u32;
 }
 
+type Title = String;
+type Description = String;
+
 #[derive(Clone, Debug)]
 pub enum CmdInfo {
     StatusModified(bool),
@@ -48,6 +51,7 @@ pub enum CmdInfo {
     Branch(String),
     CommitSummary(String),
     CommitMessage(String),
+    CommitBody(Title, Description),
     Project(Project),
     Members(Vec<Member>),
     MergeRequest(MergeRequestResponse),


### PR DESCRIPTION
This merge request adds support for reading merge request title and description text directly from files.
Provide --body-from-file cli arg.
