### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Some benefits:
 * Written in Rust. Fast and Parallelizes operations to gather data locally and
   remotely.
 * Common defaults. For example, the title of a pull requests is automatically
-  set to the last commit. Defaults can be overriden when prompted.
+  set to the last commit. Defaults can be overridden when prompted.
 * Caches API read calls. Common remote calls like gather project data that does
   not change often (project id, namespace, members), so subsequent calls are
   very fast.

--- a/doc/src/cmds/amps.md
+++ b/doc/src/cmds/amps.md
@@ -48,7 +48,7 @@ This command will prompt you to select an amp from the list of available amps.
 After selecting the amp name, it will prompt you to enter the arguments for the
 amp. Upon pressing enter, the amp will be executed.
 
-The prompt undertands the following prompt queries once an amp has been
+The prompt understands the following prompt queries once an amp has been
 selected:
 
 - `h` or `help` - Show help message for the selected amp.

--- a/doc/src/configuration.md
+++ b/doc/src/configuration.md
@@ -26,7 +26,7 @@ API token and the optional sections.
 ## TOML domain sections
 
 The configuration file is divided into sections. Each section is named after the
-domain you are targetting. The formatting of the sections is as follows. Dots in
+domain you are targeting. The formatting of the sections is as follows. Dots in
 the domain name are replaced by underscores.
 
 ```toml

--- a/doc/src/listing.md
+++ b/doc/src/listing.md
@@ -17,5 +17,5 @@ throttle interval with `--throttle` or a random one with `--throttle-range`.
 ## Max pages to fetch
 
 If no configuration is provided, the default is a max of 10 pages. This can be
-overriden with `--to-page` where it will fetch up to the specified page or a
+overridden with `--to-page` where it will fetch up to the specified page or a
 range of pages with `--from-page` and `--to-page`.

--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -39,7 +39,7 @@ pub trait MergeRequest {
 }
 
 pub trait RemoteProject {
-    /// Get the project data from the remote API. Implementors will need to pass
+    /// Get the project data from the remote API. Implementers will need to pass
     /// either an `id` or a `path`. The `path` should be in the format
     /// `OWNER/PROJECT_NAME`
     fn get_project_data(&self, id: Option<i64>, path: Option<&str>) -> Result<CmdInfo>;

--- a/src/cli/merge_request.rs
+++ b/src/cli/merge_request.rs
@@ -160,7 +160,7 @@ struct CreateMergeRequest {
     #[clap(long, value_name = "OWNER/PROJECT_NAME", value_parser=validate_project_repo_path, requires = "target_branch")]
     pub target_repo: Option<String>,
     /// Target branch of the merge request instead of default project's upstream
-    /// branch. If targetting another repository, target branch is required.
+    /// branch. If targeting another repository, target branch is required.
     #[clap(long)]
     pub target_branch: Option<String>,
     /// Automatically open the browser after creating the merge request

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,7 +4,7 @@
 //! Git commands are just public functions that return a [`Result<CmdInfo>`].
 //! The [`CmdInfo`] is an enum that defines the different types of information
 //! returned by git operations. These operations can execute in parallel and the
-//! result can be combined at the end to make a decission before opening a merge
+//! result can be combined at the end to make a decision before opening a merge
 //! request.
 //!
 //! All public functions take a [`Runner`] as a parameter and return a

--- a/src/github/merge_request.rs
+++ b/src/github/merge_request.rs
@@ -254,7 +254,7 @@ impl<R: HttpRunner<Response = HttpResponse>> MergeRequest for Github<R> {
         );
         if args.assignee.is_some() || args.author.is_some() {
             // Pull requests for the current authenticated user.
-            // Filter those reponses that have pull_request not empty See ref:
+            // Filter those responses that have pull_request not empty See ref:
             // https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-issues-assigned-to-the-authenticated-user
             // Quoting Github's docs: Note: GitHub's REST API considers every
             // pull request an issue, but not every issue is a pull request. For
@@ -697,7 +697,7 @@ mod test {
         let responses = ResponseContracts::new(ContractType::Github)
             .add_contract(200, "merge_request.json", None)
             .add_contract(201, "merge_request.json", None);
-        // current repo, targetting jordilin/gitar
+        // current repo, targeting jordilin/gitar
         let client_type = ClientType::Github(
             Domain("github.com".to_string()),
             BasePath("jdoe/gitar".to_string()),

--- a/src/gitlab/merge_request.rs
+++ b/src/gitlab/merge_request.rs
@@ -582,7 +582,7 @@ mod test {
 
     #[test]
     fn test_open_merge_request_target_repo() {
-        // current repo, targetting jordilin/gitar
+        // current repo, targeting jordilin/gitar
         let client_type = ClientType::Gitlab(
             Domain("gitlab.com".to_string()),
             BasePath("jdoe/gitar".to_string()),

--- a/src/gitlab/release.rs
+++ b/src/gitlab/release.rs
@@ -56,11 +56,11 @@ impl<R: HttpRunner<Response = HttpResponse>> Gitlab<R> {
 impl<R: HttpRunner<Response = HttpResponse>> DeployAsset for Gitlab<R> {
     fn list(&self, args: ReleaseAssetListBodyArgs) -> Result<Vec<ReleaseAssetMetadata>> {
         let release = self.get_release(args)?;
-        let mut asset_metatadata = Vec::new();
-        build_release_assets(&release, &mut asset_metatadata, AssetType::Sources);
+        let mut asset_metadata = Vec::new();
+        build_release_assets(&release, &mut asset_metadata, AssetType::Sources);
         // _links is considered an asset in the Gitlab API, include those too.
-        build_release_assets(&release, &mut asset_metatadata, AssetType::Links);
-        Ok(asset_metatadata)
+        build_release_assets(&release, &mut asset_metadata, AssetType::Links);
+        Ok(asset_metadata)
     }
 
     fn num_pages(&self, args: ReleaseAssetListBodyArgs) -> Result<Option<u32>> {
@@ -98,7 +98,7 @@ impl AsRef<str> for AssetType {
 
 fn build_release_assets(
     release: &serde_json::Value,
-    asset_metatadata: &mut Vec<ReleaseAssetMetadata>,
+    asset_metadata: &mut Vec<ReleaseAssetMetadata>,
     asset_type: AssetType,
 ) {
     let assets = release["assets"][asset_type.as_ref()].as_array().unwrap();
@@ -114,7 +114,7 @@ fn build_release_assets(
             .updated_at(release["released_at"].as_str().unwrap().to_string())
             .build()
             .unwrap();
-        asset_metatadata.push(asset_data);
+        asset_metadata.push(asset_data);
     }
 }
 

--- a/src/http/throttle.rs
+++ b/src/http/throttle.rs
@@ -15,7 +15,7 @@ use crate::{
 /// Throttle strategy
 pub trait ThrottleStrategy {
     /// Throttle the request based on optional flow control headers.
-    /// Implementors might use the headers to adjust the throttling or ignore
+    /// Implementers might use the headers to adjust the throttling or ignore
     /// them altogether. Ex. strategies could be a fixed delay, random, or based
     /// on rate limiting headers.
     fn throttle(&self, flow_control_headers: Option<&FlowControlHeaders>);

--- a/src/io.rs
+++ b/src/io.rs
@@ -30,8 +30,8 @@ pub trait TaskRunner {
         T::Item: AsRef<OsStr>;
 }
 
-/// A trait for the HTTP protocol. Implementors need to conform with the HTTP
-/// constraints and requirements. Implementors accept a `Request` that wraps
+/// A trait for the HTTP protocol. Implementers need to conform with the HTTP
+/// constraints and requirements. Implementers accept a `Request` that wraps
 /// headers, payloads and HTTP methods. Clients can potentially do HTTP calls
 /// against a remote server or mock the responses for testing purposes.
 pub trait HttpRunner {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn handle_cli_options(
         CliOptions::MergeRequest(options) => {
             let url = if let MergeRequestOptions::Create(opts) = &options {
                 // This is a create merge request operation. The remote URL that
-                // we are targetting is either our own or the remote of our
+                // we are targeting is either our own or the remote of our
                 // fork specified with --target-repo
                 let reqs = vec![CliDomainRequirements::CdInLocalRepo];
                 remote::url(

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -584,7 +584,7 @@ pub fn url<R: TaskRunner<Response = ShellResponse>>(
 /// Reads configuration from TOML file. The config_file is the main default
 /// config file and it holds global configuration. Additionally, this function
 /// will attempt to gather configurations named after the domain and the project
-/// we are targetting. This is so the main config does not become unnecessarily
+/// we are targeting. This is so the main config does not become unnecessarily
 /// large when providing merge request configuration for a specific project. The
 /// total configuration is as if we concatenated them all into one, so headers
 /// cannot be named the same across different configuration files. The


### PR DESCRIPTION
Found via `codespell -L gitar,crate,ser` and `typos --hidden --format brief`