### PR TITLE
http: Keep empty body in response on failure

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -95,7 +95,7 @@ impl<C> Client<C> {
                 let mut response = HttpResponse::builder()
                     .status(status.as_u16() as i32)
                     .headers(headers)
-                    .body(body.read_to_string()?)
+                    .body(body.read_to_string().unwrap_or_default())
                     .flow_control_headers(flow_control_headers)
                     .build()
                     .unwrap();


### PR DESCRIPTION
Keeps same functionality as before. If remote
sends a 304, the ureq fails to parse the body when
"content-encoding": "gzip" and there's no body.
Error `gzip decompression failed: unexpected end
of file`.
Use unwrap_or_default to set the body empty and
return the cached response instead.