### PR TITLE
http_test: Add content-encoding on 304 response test

### DIFF
--- a/tests/http_test.rs
+++ b/tests/http_test.rs
@@ -169,6 +169,7 @@ fn test_http_gathers_from_inmemory_stale_cache_server_304() {
                 .path("/repos/jordilin/mr/members");
             then.status(304)
                 .header("content-type", "application/json")
+                .header("content-encoding", "gzip")
                 .body("");
         }
     });


### PR DESCRIPTION
This will make sure the client handles an empty body correctly when the
server responds with a 304.